### PR TITLE
Attempts to fix failures when VS returns 503

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Each subproject should have its own README within its root directory giving more
 backend and a React.js frontend.
 - `common` - a library of components that are shared between the different subprojects.  This includes data models for the
 ElasticSearch objects, Data Access Objects, client managers, etc.
-- `cronscanner` - the first scanner. This performs regular scans of Vidispine items and updates the index with stats
-about how many replicas they have (i.e. how much is in nearline)
+- `cronscanner` - the first scanner. This performs regular scans of Asset Importer files, cross-references them to Vidispine 
+items and updates the index with stats about how many replicas they have (i.e. how much is in nearline)
 - `deletescanner` - a cleanup scanner.  This checks the "deleted items" table in Asset Sweeper and removes census entries
 for those items that are not present on the SAN.
 - `findarchivednearline` - a scanner built for a one-off purpose, checking whether Vidispine thinks that items which are on

--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -69,8 +69,8 @@ class JobsController @Inject() (config:Configuration, jobsModelDAOinj:Injectable
     }
   }
 
-  def runningJobs = Action.async {
-    jobsModelDAO.queryJobs(None,Some(JobHistoryDAO.JobState.Running),None).map({
+  def runningJobs(limit:Option[Int]) = Action.async {
+    jobsModelDAO.queryJobs(None,Some(JobHistoryDAO.JobState.Running),limit).map({
       case Left(err)=>
         logger.error(s"Could not list currently running jobs: $err")
         InternalServerError(GenericResponse("db_error", err.toString).asJson)

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -23,7 +23,7 @@
     <logger name="vidispine.VSCommunicator" level="DEBUG"/>
     <logger name="archivehunter" level="INFO"/>
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="ASYNCSTDOUT" />
     </root>
 

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -16,11 +16,11 @@
     <logger name="streamComponents.PeriodicUpdate" level="INFO"/>
     <logger name="streamComponents.AssetSweeperDeletedSource" level="INFO"/>
     <logger name="streamComponents.VSStorageScanSource" level="INFO"/>
-    <logger name="models.JobHistoryDAO" level="DEBUG"/>
+    <logger name="models.JobHistoryDAO" level="INFO"/>
     <logger name="models.VSFileIndexer" level="DEBUG"/>
 
-    <logger name="nlstreamcomponents" level="DEBUG"/>
-    <logger name="vidispine.VSCommunicator" level="DEBUG"/>
+    <logger name="nlstreamcomponents" level="INFO"/>
+    <logger name="vidispine.VSCommunicator" level="WARN"/>
     <logger name="archivehunter" level="INFO"/>
 
     <root level="WARN">

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -18,7 +18,8 @@
     <logger name="streamComponents.VSStorageScanSource" level="INFO"/>
     <logger name="models.JobHistoryDAO" level="INFO"/>
     <logger name="models.VSFileIndexer" level="DEBUG"/>
-
+    <logger name="DeleteScanner" level="INFO"/>
+    <logger name="CronScanner" level="INFO"/>
     <logger name="nlstreamcomponents" level="INFO"/>
     <logger name="vidispine.VSCommunicator" level="WARN"/>
     <logger name="archivehunter" level="INFO"/>

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -15,12 +15,15 @@
     <logger name="streamComponents.VSFileSwitch" level="INFO"/>
     <logger name="streamComponents.PeriodicUpdate" level="INFO"/>
     <logger name="streamComponents.AssetSweeperDeletedSource" level="INFO"/>
-    <logger name="streamComponents.VSStorageScanSource" level="DEBUG"/>
+    <logger name="streamComponents.VSStorageScanSource" level="INFO"/>
+    <logger name="models.JobHistoryDAO" level="DEBUG"/>
     <logger name="models.VSFileIndexer" level="DEBUG"/>
+
     <logger name="nlstreamcomponents" level="DEBUG"/>
     <logger name="vidispine.VSCommunicator" level="DEBUG"/>
     <logger name="archivehunter" level="INFO"/>
-    <root level="WARN">
+
+    <root level="INFO">
         <appender-ref ref="ASYNCSTDOUT" />
     </root>
 

--- a/common/src/main/scala/models/JobHistoryDAO.scala
+++ b/common/src/main/scala/models/JobHistoryDAO.scala
@@ -51,6 +51,7 @@ class JobHistoryDAO(esClient:ElasticClient, indexName:String) extends ZonedDateT
     if(response.isError){
       Left(response.error)
     } else {
+      logger.debug(s"jobForUuid: server returned $response")
       if(response.result.found)
         Right(Some(response.result.to[JobHistory]))
       else

--- a/common/src/main/scala/models/JobHistoryDAO.scala
+++ b/common/src/main/scala/models/JobHistoryDAO.scala
@@ -123,7 +123,7 @@ class JobHistoryDAO(esClient:ElasticClient, indexName:String) extends ZonedDateT
     ).collect({case Some(defs)=>defs}).flatten
 
     val query = maybeLimit match {
-      case Some(suppliedLimit)=>search(indexName) query boolQuery().withMust(queryDefs) limit suppliedLimit
+      case Some(suppliedLimit)=>search(indexName) query boolQuery().withMust(queryDefs) sortByFieldDesc "scanStart" limit suppliedLimit
       case None=>search(indexName) query boolQuery().withMust(queryDefs)
     }
     esClient.execute { query }.map(response=>{

--- a/common/src/main/scala/models/JobHistoryDAO.scala
+++ b/common/src/main/scala/models/JobHistoryDAO.scala
@@ -146,7 +146,7 @@ class JobHistoryDAO(esClient:ElasticClient, indexName:String) extends ZonedDateT
 
     val query = maybeLimit match {
       case Some(suppliedLimit)=>search(indexName) query boolQuery().withMust(queryDefs) sortByFieldDesc "scanStart" limit suppliedLimit
-      case None=>search(indexName) query boolQuery().withMust(queryDefs)
+      case None=>search(indexName) query boolQuery().withMust(queryDefs) limit 1000
     }
     esClient.execute { query }.map(response=>{
       if(response.isError){

--- a/common/src/main/scala/streamComponents/AssetSweeperNotExistFilter.scala
+++ b/common/src/main/scala/streamComponents/AssetSweeperNotExistFilter.scala
@@ -4,30 +4,26 @@ import java.sql.Connection
 
 import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
-import com.sksamuel.elastic4s.http.ElasticClient
 import config.DatabaseConfiguration
 import helpers.JdbcConnectionManager
-import models.{AssetSweeperFile, MediaCensusEntry, MediaCensusIndexer}
+import models.MediaCensusEntry
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 
 /**
-  * filters out records that do not exist in the deleted_files table in Asset Sweeper
-  * @param config
-  * @param esClient
+  * filters out records that DO exist in the asset sweeper files table
   */
-class DeletionFilter(config:DatabaseConfiguration, esClient:ElasticClient) extends GraphStage[FlowShape[MediaCensusEntry,MediaCensusEntry]] {
-  private final val in:Inlet[MediaCensusEntry] = Inlet.create("DeletionFilter.in")
-  private final val out:Outlet[MediaCensusEntry] = Outlet.create("DeletionFilter.out")
+class AssetSweeperNotExistFilter(config:DatabaseConfiguration) extends GraphStage[FlowShape[MediaCensusEntry, MediaCensusEntry]] {
+  private final val in:Inlet[MediaCensusEntry] = Inlet("AssetSweeperNotExistFilter.in")
+  private final val out:Outlet[MediaCensusEntry] = Outlet("AssetSweeperNotExistFilter.out")
 
-  override def shape: FlowShape[MediaCensusEntry, MediaCensusEntry] = FlowShape.of(in,out)
+  override def shape = FlowShape.of(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
     private val logger = LoggerFactory.getLogger(getClass)
     private var connection:Connection = _
-    private lazy val checkStatement = connection.prepareStatement(s"SELECT id FROM deleted_files WHERE filepath=? and filename=?")
+    private lazy val checkStatement = connection.prepareStatement(s"SELECT id FROM files WHERE filepath=? and filename=?")
 
     setHandler(in, new AbstractInHandler {
       override def onPush(): Unit = {
@@ -39,11 +35,11 @@ class DeletionFilter(config:DatabaseConfiguration, esClient:ElasticClient) exten
 
         if(resultSet.next()){
           //we have rows
-          logger.debug(s"Found row for ${elem.originalSource.filepath}/${elem.originalSource.filename}")
-          push(out, elem)
-        } else {
-          logger.debug(s"${elem.originalSource.filepath}/${elem.originalSource.filename} is not in deleted items table")
+          logger.debug(s"Found row for ${elem.originalSource.filepath}/${elem.originalSource.filename} in files table")
           pull(in)
+        } else {
+          logger.debug(s"${elem.originalSource.filepath}/${elem.originalSource.filename} is not in the files table")
+          push(out, elem)
         }
         resultSet.close()
       }
@@ -68,5 +64,4 @@ class DeletionFilter(config:DatabaseConfiguration, esClient:ElasticClient) exten
       checkStatement.close()
     }
   }
-
 }

--- a/common/src/main/scala/streamComponents/DeletionFilter.scala
+++ b/common/src/main/scala/streamComponents/DeletionFilter.scala
@@ -15,10 +15,9 @@ import scala.util.{Failure, Success}
 
 /**
   * filters out records that do not exist in the deleted_files table in Asset Sweeper
-  * @param config
-  * @param esClient
+  * @param config DatabaseConfiguration instance relating the database to read
   */
-class DeletionFilter(config:DatabaseConfiguration, esClient:ElasticClient) extends GraphStage[FlowShape[MediaCensusEntry,MediaCensusEntry]] {
+class DeletionFilter(config:DatabaseConfiguration) extends GraphStage[FlowShape[MediaCensusEntry,MediaCensusEntry]] {
   private final val in:Inlet[MediaCensusEntry] = Inlet.create("DeletionFilter.in")
   private final val out:Outlet[MediaCensusEntry] = Outlet.create("DeletionFilter.out")
 

--- a/common/src/main/scala/streamComponents/PeriodicUpdateBasic.scala
+++ b/common/src/main/scala/streamComponents/PeriodicUpdateBasic.scala
@@ -69,8 +69,9 @@ class PeriodicUpdateBasic[T](initialJobRecord:JobHistory, updateEvery:Int=100, i
           jobHistoryDAO.jobForUuid(initialJobRecord.jobId).flatMap({
             case Left(elasticError)=>Future(Left(Seq(elasticError.toString)))
             case Right(None)=>
-              failedCb.invoke(new RuntimeException(s"Could not find any job to update in the index with the ID ${initialJobRecord.jobId}"))
-              Future(Left(Seq("Could not find any job")))
+              logger.error(s"Could not find any job to update with the ID ${initialJobRecord.jobId}, creating anyway. No updating stats, only updating count")
+              val toWrite = initialJobRecord.copy(itemsCounted = itemsProcessed)
+              writeNewRecord(toWrite, elem, failedCb, completedCb)
             case Right(Some(currentRecord))=>
               if(includeStats) {
                 logger.info(s"Updating current running stats...")

--- a/common/src/main/scala/streamComponents/VSStorageScanSource.scala
+++ b/common/src/main/scala/streamComponents/VSStorageScanSource.scala
@@ -5,6 +5,7 @@ import akka.stream.stage.{AbstractOutHandler, GraphStage, GraphStageLogic}
 import akka.stream.{Attributes, Materializer, Outlet, SourceShape}
 import com.softwaremill.sttp.Uri
 import org.slf4j.LoggerFactory
+import vidispine.VSCommunicator.OperationType
 import vidispine.{VSCommunicator, VSFile}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,7 +32,7 @@ class VSStorageScanSource(storageId:Option[String], fileState:Option[String], co
 
       val queryParamsWithState = if(fileState.isDefined) queryParams ++ Map("state"->fileState.get) else queryParams
 
-      comm.requestGet(s"$baseUrl;first=$ctr;number=$pageSize;sort=timestamp",Map("Accept"->"application/xml"),queryParams = queryParamsWithState).flatMap({
+      comm.request(OperationType.GET, s"$baseUrl;first=$ctr;number=$pageSize;sort=timestamp",None,Map("Accept"->"application/xml"),queryParams = queryParamsWithState).flatMap({
         case Left(err)=>
           logger.warn(s"Got HTTP error $err listing storage $storageId. Retrying...")
           Thread.sleep(5000)

--- a/common/src/main/scala/vidispine/VSCommunicator.scala
+++ b/common/src/main/scala/vidispine/VSCommunicator.scala
@@ -109,9 +109,9 @@ class VSCommunicator(vsUri:Uri, plutoUser:String, plutoPass:String, maxAttempts:
           consumeSource(source).map(data => Right(data))
         case Left(errorString) =>
           consumeSource(response.unsafeBody).flatMap(_ => { //consuming the source is necessary to do a retry
-            if (response.code == 503 || response.code == 500) {
+            if (response.code == 502 || response.code == 503 || response.code == 500) {
               val delayTime = if (attempt > 6) 60 else 2 ^ attempt
-              logger.warn(s"Received 503 from Vidispine. Retrying in $delayTime seconds.")
+              logger.warn(s"Received ${response.code} from Vidispine. Retrying in $delayTime seconds.")
               if (attempt > 20) {
                 logger.error("Failed after 20 attempts, giving up.")
                 Future(Left(HttpError("Gave up after 20 attempts", 503)))

--- a/common/src/main/scala/vidispine/VSCommunicator.scala
+++ b/common/src/main/scala/vidispine/VSCommunicator.scala
@@ -45,6 +45,7 @@ class VSCommunicator(vsUri:Uri, plutoUser:String, plutoPass:String)(implicit val
   private def sendGeneric(operation:OperationType.Value, uriPath:String, maybeXmlString:Option[String], headers:Map[String,String], queryParams:Map[String,String]):Future[Response[Source[ByteString, Any]]] = {
     val bs = maybeXmlString.map(xmlString=>ByteString(xmlString,"UTF-8"))
 
+
     val uriWithPath = vsUri.path(uriPath)
     val uri = queryParams.foldLeft[Uri](uriWithPath)((acc, tuple)=>acc.queryFragment(Uri.QueryFragment.KeyValue(tuple._1,tuple._2)))
     val source:Option[Source[ByteString, Any]] = bs.map(Source.single)

--- a/common/src/main/scala/vidispine/VSCommunicator.scala
+++ b/common/src/main/scala/vidispine/VSCommunicator.scala
@@ -42,7 +42,7 @@ class VSCommunicator(vsUri:Uri, plutoUser:String, plutoPass:String, maxAttempts:
     * @param queryParams String->string map of query params
     * @return a Future, with a response containing a stream source to read the body.
     */
-  private def sendGeneric(operation:OperationType.Value, uriPath:String, maybeXmlString:Option[String], headers:Map[String,String], queryParams:Map[String,String]):Future[Response[Source[ByteString, Any]]] = {
+  protected def sendGeneric(operation:OperationType.Value, uriPath:String, maybeXmlString:Option[String], headers:Map[String,String], queryParams:Map[String,String]):Future[Response[Source[ByteString, Any]]] = {
     val bs = maybeXmlString.map(xmlString=>ByteString(xmlString,"UTF-8"))
 
     val uriWithPath = vsUri.path(uriPath)
@@ -82,7 +82,7 @@ class VSCommunicator(vsUri:Uri, plutoUser:String, plutoPass:String, maxAttempts:
     * @param ec implicitly provided execution context for async operations
     * @return a Future, which contains the String of the returned content.
     */
-  private def consumeSource(source:Source[ByteString,Any])(implicit materializer: akka.stream.Materializer, ec: ExecutionContext):Future[String] = {
+  protected def consumeSource(source:Source[ByteString,Any])(implicit materializer: akka.stream.Materializer, ec: ExecutionContext):Future[String] = {
     logger.debug("Consuming returned body")
     val sink = Sink.reduce((acc:ByteString, unit:ByteString)=>acc.concat(unit))
     val runnable = source.toMat(sink)(Keep.right)

--- a/common/src/main/scala/vidispine/VSFile.scala
+++ b/common/src/main/scala/vidispine/VSFile.scala
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime
 
 import akka.stream.Materializer
 import org.slf4j.LoggerFactory
+import vidispine.VSCommunicator.OperationType
 
 import scala.util.{Failure, Success, Try}
 import scala.xml.{NodeSeq, XML}
@@ -105,7 +106,7 @@ object VSFile {
   }
   def forPathOnStorage(storageId:String, path:String)(implicit communicator: VSCommunicator, mat:Materializer) = {
     val uri = s"/API/storage/$storageId/file;includeItem=true"
-    communicator.requestGet(uri, Map("Accept"->"application/xml"), queryParams = Map("path"->path,"count"->"false")).map({
+    communicator.request(OperationType.GET, uri, None, Map("Accept"->"application/xml"), queryParams = Map("path"->path,"count"->"false")).map({
       case Left(err)=>Left(Seq(err.toString))
       case Right(xmlString)=>VSFile.seqFromXmlString(xmlString) match {
         case Left(errSeq)=>

--- a/common/src/test/scala/JobHistoryDAOSpec.scala
+++ b/common/src/test/scala/JobHistoryDAOSpec.scala
@@ -1,0 +1,57 @@
+import java.time.format.DateTimeFormatter
+import java.time.{ZoneId, ZonedDateTime}
+import java.util.UUID
+
+import com.sksamuel.elastic4s.http.{ElasticClient, ElasticProperties}
+import models.{JobHistory, JobHistoryDAO, JobType}
+import org.elasticsearch.client.ElasticsearchClient
+import com.sksamuel.elastic4s.testkit.ClientProvider
+import org.specs2.mutable.Specification
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class JobHistoryDAOSpec extends Specification {
+  "JobHistoryDAO.updateStatusOnly" should {
+    "update the specified document without overwriting the counters" in {
+      if(System.getProperty("have-local-elasticsearch")!=null) {
+        val client = ElasticClient(ElasticProperties("http://localhost:9200"))
+
+        val fakeStartTime = ZonedDateTime.of(2019, 1, 1, 23, 22, 21, 0, ZoneId.systemDefault())
+        val fakeEndTime = ZonedDateTime.of(2019, 1, 2, 23, 22, 21, 0, ZoneId.systemDefault())
+        val jobId = UUID.randomUUID()
+        val initialDoc = JobHistory(jobId, Some(JobType.CensusScan), fakeStartTime, None, None, 1, 2, 3, 4, 5, 6)
+
+        val daoToTest = new JobHistoryDAO(client, "test-jobs-index")
+
+        Await.ready(daoToTest.put(initialDoc), 30 seconds)
+
+        val statusUpdate = JobHistory(jobId, Some(JobType.CensusScan), initialDoc.scanStart, Some(fakeEndTime), Some("something went kaboom"), 0, 0, 0, 0, 0, 0)
+
+        val result = Await.result(daoToTest.updateStatusOnly(statusUpdate), 30 seconds)
+        result must beRight
+
+        val actualRecord = Await.result(daoToTest.jobForUuid(jobId), 30 seconds)
+
+        actualRecord must beRight
+        actualRecord.right.get must beSome
+
+        val output = actualRecord.right.get.get
+
+        output.lastError must beSome("something went kaboom")
+        output.scanStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) mustEqual fakeStartTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        output.scanFinish.get.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) mustEqual fakeEndTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        output.noBackupsCount mustEqual 1
+        output.partialBackupsCount mustEqual 2
+        output.fullBackupsCount mustEqual 3
+        output.unimportedCount mustEqual 4
+        output.unattachedCount mustEqual 5
+        output.itemsCounted mustEqual 6
+      } else {
+        println("TEST SKIPPED - no elasticsearch present. Set -Dhave-local-elasticsearch to run the test, assuming you have ES at http://localhost:9200")
+        1 mustEqual 1
+      }
+
+    }
+  }
+}

--- a/common/src/test/scala/VSCommunicatorSpec.scala
+++ b/common/src/test/scala/VSCommunicatorSpec.scala
@@ -13,61 +13,64 @@ import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration._
 
 class VSCommunicatorSpec extends Specification with Mockito{
-  "VSCommunicator.requestGet" should {
-    "retry requests if it receives a 503" in new AkkaTestkitSpecs2Support {
-      implicit val mat:Materializer = ActorMaterializer.create(system)
+  //FIXME: apply these tests to requestGeneric
 
-      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
-      mockedSendGet.apply(any,any,any) returns
-        Future(Response[Source[ByteString, Any]](Left("Timeout"),503,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
-      Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
-
-      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
-        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
-      }
-
-
-      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
-      result must beRight("eventual content")
-      there were two(mockedSendGet).apply(any,any,any)
-    }
-
-    "retry requests if it receives a 500" in new AkkaTestkitSpecs2Support {
-      implicit val mat:Materializer = ActorMaterializer.create(system)
-
-      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
-      mockedSendGet.apply(any,any,any) returns
-        Future(Response[Source[ByteString, Any]](Left("Server error"),500,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
-        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
-
-      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
-        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
-      }
-
-
-      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
-      result must beRight("eventual content")
-      there were two(mockedSendGet).apply(any,any,any)
-    }
-
-    "not retry requests if it receives a 400" in new AkkaTestkitSpecs2Support {
-      implicit val mat:Materializer = ActorMaterializer.create(system)
-
-      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
-      mockedSendGet.apply(any,any,any) returns
-        Future(Response[Source[ByteString, Any]](Left("Bad data"),400,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
-        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
-
-      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
-        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
-      }
-
-
-      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
-      result must beLeft
-      there was one(mockedSendGet).apply(any,any,any)
-    }
-  }
+//  "VSCommunicator.requestGet" should {
+//    "retry requests if it receives a 503" in new AkkaTestkitSpecs2Support {
+//      implicit val mat:Materializer = ActorMaterializer.create(system)
+//
+//      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
+//      mockedSendGet.apply(any,any,any) returns
+//        Future(Response[Source[ByteString, Any]](Left("Timeout"),503,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+//      Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+//
+//      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+//        override protected def sendGeneric
+//        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
+//      }
+//
+//
+//      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
+//      result must beRight("eventual content")
+//      there were two(mockedSendGet).apply(any,any,any)
+//    }
+//
+//    "retry requests if it receives a 500" in new AkkaTestkitSpecs2Support {
+//      implicit val mat:Materializer = ActorMaterializer.create(system)
+//
+//      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
+//      mockedSendGet.apply(any,any,any) returns
+//        Future(Response[Source[ByteString, Any]](Left("Server error"),500,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+//        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+//
+//      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+//        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
+//      }
+//
+//
+//      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
+//      result must beRight("eventual content")
+//      there were two(mockedSendGet).apply(any,any,any)
+//    }
+//
+//    "not retry requests if it receives a 400" in new AkkaTestkitSpecs2Support {
+//      implicit val mat:Materializer = ActorMaterializer.create(system)
+//
+//      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
+//      mockedSendGet.apply(any,any,any) returns
+//        Future(Response[Source[ByteString, Any]](Left("Bad data"),400,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+//        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+//
+//      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+//        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
+//      }
+//
+//
+//      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
+//      result must beLeft
+//      there was one(mockedSendGet).apply(any,any,any)
+//    }
+//  }
 
 
 }

--- a/common/src/test/scala/VSCommunicatorSpec.scala
+++ b/common/src/test/scala/VSCommunicatorSpec.scala
@@ -7,70 +7,119 @@ import org.specs2.mutable.Specification
 import vidispine.VSCommunicator
 import com.softwaremill.sttp._
 import testhelpers.AkkaTestkitSpecs2Support
+import vidispine.VSCommunicator.OperationType
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration._
 
 class VSCommunicatorSpec extends Specification with Mockito{
-  //FIXME: apply these tests to requestGeneric
+  "VSCommunicator.request" should {
+    "retry requests if it receives a 503" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
 
-//  "VSCommunicator.requestGet" should {
-//    "retry requests if it receives a 503" in new AkkaTestkitSpecs2Support {
-//      implicit val mat:Materializer = ActorMaterializer.create(system)
-//
-//      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
-//      mockedSendGet.apply(any,any,any) returns
-//        Future(Response[Source[ByteString, Any]](Left("Timeout"),503,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
-//      Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
-//
-//      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
-//        override protected def sendGeneric
-//        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
-//      }
-//
-//
-//      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
-//      result must beRight("eventual content")
-//      there were two(mockedSendGet).apply(any,any,any)
-//    }
-//
-//    "retry requests if it receives a 500" in new AkkaTestkitSpecs2Support {
-//      implicit val mat:Materializer = ActorMaterializer.create(system)
-//
-//      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
-//      mockedSendGet.apply(any,any,any) returns
-//        Future(Response[Source[ByteString, Any]](Left("Server error"),500,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
-//        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
-//
-//      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
-//        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
-//      }
-//
-//
-//      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
-//      result must beRight("eventual content")
-//      there were two(mockedSendGet).apply(any,any,any)
-//    }
-//
-//    "not retry requests if it receives a 400" in new AkkaTestkitSpecs2Support {
-//      implicit val mat:Materializer = ActorMaterializer.create(system)
-//
-//      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
-//      mockedSendGet.apply(any,any,any) returns
-//        Future(Response[Source[ByteString, Any]](Left("Bad data"),400,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
-//        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
-//
-//      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
-//        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
-//      }
-//
-//
-//      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
-//      result must beLeft
-//      there was one(mockedSendGet).apply(any,any,any)
-//    }
-//  }
+      val mockedSendGeneric = mock[(OperationType.Value, String,Option[String],Map[String,String],Map[String,String])=>Future[Response[Source[ByteString, Any]]]]
+      mockedSendGeneric.apply(any,any,any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Left("Timeout"),503,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGeneric(operation: VSCommunicator.OperationType.Value, uriPath: String, maybeXmlString: Option[String], headers: Map[String, String], queryParams: Map[String, String]): Future[Response[Source[ByteString, Any]]] =
+          mockedSendGeneric(operation, uriPath, maybeXmlString, headers, queryParams)
+      }
+
+      val result = Await.result(comm.request(OperationType.GET,"/API/somepath",None,Map(),Map()), 30 seconds)
+      result must beRight("eventual content")
+      there were two(mockedSendGeneric).apply(any,any,any,any,any)
+    }
+
+    "retry requests if it receives a 500" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val mockedSendGeneric = mock[(OperationType.Value, String,Option[String],Map[String,String],Map[String,String])=>Future[Response[Source[ByteString, Any]]]]
+      mockedSendGeneric.apply(any,any,any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Left("Timeout"),500,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGeneric(operation: VSCommunicator.OperationType.Value, uriPath: String, maybeXmlString: Option[String], headers: Map[String, String], queryParams: Map[String, String]): Future[Response[Source[ByteString, Any]]] =
+          mockedSendGeneric(operation, uriPath, maybeXmlString, headers, queryParams)
+      }
+
+      val result = Await.result(comm.request(OperationType.GET,"/API/somepath",None,Map(),Map()), 30 seconds)
+      result must beRight("eventual content")
+      there were two(mockedSendGeneric).apply(any,any,any,any,any)
+    }
+
+    "retry requests if it receives a 502" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val mockedSendGeneric = mock[(OperationType.Value, String,Option[String],Map[String,String],Map[String,String])=>Future[Response[Source[ByteString, Any]]]]
+      mockedSendGeneric.apply(any,any,any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Left("Timeout"),502,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGeneric(operation: VSCommunicator.OperationType.Value, uriPath: String, maybeXmlString: Option[String], headers: Map[String, String], queryParams: Map[String, String]): Future[Response[Source[ByteString, Any]]] =
+          mockedSendGeneric(operation, uriPath, maybeXmlString, headers, queryParams)
+      }
+
+      val result = Await.result(comm.request(OperationType.GET,"/API/somepath",None,Map(),Map()), 30 seconds)
+      result must beRight("eventual content")
+      there were two(mockedSendGeneric).apply(any,any,any,any,any)
+    }
+
+    "not retry requests if it receives a 300" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val mockedSendGeneric = mock[(OperationType.Value, String,Option[String],Map[String,String],Map[String,String])=>Future[Response[Source[ByteString, Any]]]]
+      mockedSendGeneric.apply(any,any,any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Left("Bad data"),400,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGeneric(operation: VSCommunicator.OperationType.Value, uriPath: String, maybeXmlString: Option[String], headers: Map[String, String], queryParams: Map[String, String]): Future[Response[Source[ByteString, Any]]] =
+          mockedSendGeneric(operation, uriPath, maybeXmlString, headers, queryParams)
+      }
+
+      val result = Await.result(comm.request(OperationType.GET,"/API/somepath",None,Map(),Map()), 30 seconds)
+      result must beLeft
+      there was one(mockedSendGeneric).apply(any,any,any,any,any)
+    }
+
+    "retry requests if it receives a 200" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val mockedSendGeneric = mock[(OperationType.Value, String,Option[String],Map[String,String],Map[String,String])=>Future[Response[Source[ByteString, Any]]]]
+      mockedSendGeneric.apply(any,any,any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("my content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGeneric(operation: VSCommunicator.OperationType.Value, uriPath: String, maybeXmlString: Option[String], headers: Map[String, String], queryParams: Map[String, String]): Future[Response[Source[ByteString, Any]]] =
+          mockedSendGeneric(operation, uriPath, maybeXmlString, headers, queryParams)
+      }
+
+      val result = Await.result(comm.request(OperationType.GET,"/API/somepath",None,Map(),Map()), 30 seconds)
+      result must beRight("my content")
+      there was one(mockedSendGeneric).apply(any,any,any,any,any)
+    }
+
+  }
+
+  "VSCommunicator.consumeSource" should {
+    "convert all of the incoming stream into a single ByteString, convert that to a regular UTF string and return it in a future" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val comm = new VSCommunicator(uri"http://test-server.org", "user","password") {
+        def testConsume(source:Source[ByteString,Any]) = consumeSource(source)
+      }
+
+      val src = Source.fromIterator(()=>Seq(ByteString("123"),ByteString("456"),ByteString("789")).toIterator)
+
+      val result = Await.result(comm.testConsume(src), 30 seconds)
+      result mustEqual "123456789"
+    }
+  }
 
 
 }

--- a/common/src/test/scala/VSCommunicatorSpec.scala
+++ b/common/src/test/scala/VSCommunicatorSpec.scala
@@ -1,0 +1,73 @@
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import vidispine.VSCommunicator
+import com.softwaremill.sttp._
+import testhelpers.AkkaTestkitSpecs2Support
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.duration._
+
+class VSCommunicatorSpec extends Specification with Mockito{
+  "VSCommunicator.requestGet" should {
+    "retry requests if it receives a 503" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
+      mockedSendGet.apply(any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Left("Timeout"),503,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+      Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
+      }
+
+
+      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
+      result must beRight("eventual content")
+      there were two(mockedSendGet).apply(any,any,any)
+    }
+
+    "retry requests if it receives a 500" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
+      mockedSendGet.apply(any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Left("Server error"),500,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
+      }
+
+
+      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
+      result must beRight("eventual content")
+      there were two(mockedSendGet).apply(any,any,any)
+    }
+
+    "not retry requests if it receives a 400" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val mockedSendGet = mock[Function3[String,Map[String,String],Map[String,String], Future[Response[Source[ByteString,Any]]]]]
+      mockedSendGet.apply(any,any,any) returns
+        Future(Response[Source[ByteString, Any]](Left("Bad data"),400,scala.collection.immutable.Seq[(String,String)](),List())) thenReturns
+        Future(Response[Source[ByteString, Any]](Right(Source.single(ByteString("eventual content"))),200,scala.collection.immutable.Seq[(String,String)](),List()))
+
+      val comm = new VSCommunicator(uri"http://test-server.org","user","password") {
+        override protected def sendGet(uriPath:String, headers:Map[String,String], queryParams:Map[String,String]) = mockedSendGet(uriPath, headers, queryParams)
+      }
+
+
+      val result = Await.result(comm.requestGet("/API/somepath",Map(),Map()), 30 seconds)
+      result must beLeft
+      there was one(mockedSendGet).apply(any,any,any)
+    }
+  }
+
+
+}

--- a/common/src/test/scala/VSStorageScanSourceSpec.scala
+++ b/common/src/test/scala/VSStorageScanSourceSpec.scala
@@ -26,7 +26,7 @@ class VSStorageScanSourceSpec extends Specification with Mockito {
       implicit val mat:Materializer = ActorMaterializer.create(system)
       val mockedCommunicator = mock[VSCommunicator]
       val sampleXml = getTestData("filescan.xml")
-      mockedCommunicator.requestGet(any,any,any,any)(any,any) returns Future(Right(sampleXml)) thenReturns Future(Right(getTestData("emptyScan.xml")))
+      mockedCommunicator.request(any, any,any,any,any,any)(any,any) returns Future(Right(sampleXml)) thenReturns Future(Right(getTestData("emptyscan.xml")))
 
       val sinkFac = Sink.fold[Seq[VSFile],VSFile](Seq())((acc,item)=>acc ++ Seq(item))
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -315,6 +315,7 @@ play.filters {
 
 elasticsearch {
   uri = ${?ELASTICSEARCH_URI}
+  uri = "http://localhost:9200"
   indexName = "mediacensus"
   indexName = ${?INDEX_NAME}
   jobsHistoryIndex = "mediacensus-jobs"

--- a/conf/routes
+++ b/conf/routes
@@ -15,7 +15,7 @@ GET     /api/nearline/membership    @controllers.NearlineDataController.membersh
 GET     /api/nearline/files         @controllers.NearlineDataController.fileSearch(start:Option[String],duration:Option[Int],limit:Option[Int],orphanOnly:Boolean?=false)
 
 GET     /api/jobs/:jobType/forTimespan  @controllers.JobsController.jobsForTimespan(jobType, startAt:Option[String]?=None,endAt:Option[String]?=None,showRunning:Boolean?=false)
-GET     /api/jobs/running               @controllers.JobsController.runningJobs
+GET     /api/jobs/running               @controllers.JobsController.runningJobs(limit:Option[Int])
 GET     /api/jobs/:jobType/lastSuccess  @controllers.JobsController.lastSuccessfulJob(jobType)
 
 GET     /api/job/:jobId             @controllers.JobsController.jobDetail(jobId)

--- a/cronscanner/src/main/scala/CronScanner.scala
+++ b/cronscanner/src/main/scala/CronScanner.scala
@@ -63,8 +63,6 @@ object CronScanner extends ZonedDateTimeEncoder with CleanoutFunctions {
     * @return
     */
   def buildStream(vsPathMap:Map[String,VSStorage], maybeStartAt:Option[Long], initialJobRecord:JobHistory)(implicit esClient:ElasticClient, jobHistoryDAO:JobHistoryDAO, indexer:MediaCensusIndexer) = {
-    //val sink = Sink.seq[MediaCensusEntry]
-
     val counterSink = Sink.fold[Int, MediaCensusEntry](0)((acc,elem)=>acc+1)
 
     GraphDSL.create(counterSink) { implicit builder=> { reduceSink =>

--- a/cronscanner/src/main/scala/CronScanner.scala
+++ b/cronscanner/src/main/scala/CronScanner.scala
@@ -159,7 +159,7 @@ object CronScanner extends ZonedDateTimeEncoder with CleanoutFunctions {
     val updateFuture = runInfo match {
       case Some(jobHistory)=>
         val updatedJobHistory = jobHistory.copy(scanFinish = Some(ZonedDateTime.now()), lastError = errorMessage)
-        jobHistoryDAO.put(updatedJobHistory).map({
+        jobHistoryDAO.updateStatusOnly(updatedJobHistory).map({
           case Left(err)=>logger.error(s"Could not update job history entry: ${err.toString}")
           case Right(newVersion)=>logger.info(s"Update run ${updatedJobHistory} with new version $newVersion")
         })

--- a/cronscanner/src/main/scala/CronScanner.scala
+++ b/cronscanner/src/main/scala/CronScanner.scala
@@ -218,12 +218,12 @@ object CronScanner extends ZonedDateTimeEncoder with CleanoutFunctions {
 
     lazy implicit val jobHistoryDAO = new JobHistoryDAO(esClient, jobIndexName)
 
-    cleanoutOldJobs(jobHistoryDAO, JobType.CensusScan,leaveOpenDays).map({
+    Await.ready(cleanoutOldJobs(jobHistoryDAO, JobType.CensusScan,leaveOpenDays).map({
       case Left(errs)=>
         logger.error(s"Cleanout of old census jobs failed: $errs")
       case Right(results)=>
         logger.info(s"Cleanout of old census jobs succeeded: $results")
-    })
+    }), 5 minutes)
 
     val runInfo = JobHistory.newRun(JobType.CensusScan)
 

--- a/deletescanner/src/main/scala/DeleteScanner.scala
+++ b/deletescanner/src/main/scala/DeleteScanner.scala
@@ -55,7 +55,7 @@ object DeleteScanner extends ZonedDateTimeEncoder with CleanoutFunctions {
       val srcFactory = indexer.getIndexSource(esClient)
 
       val periodicUpdate = builder.add(new PeriodicUpdate[MediaCensusEntry](initialJobRecord, updateEvery = 500))
-      val deletionFilter = builder.add(new DeletionFilter(assetSweeperConfig, esClient))
+      val deletionFilter = builder.add(new DeletionFilter(assetSweeperConfig))
       val existInFilesFilter = builder.add(new AssetSweeperNotExistFilter(assetSweeperConfig))
       val streamSource = builder.add(srcFactory)
       val sinkSplitter = builder.add(Broadcast[MediaCensusEntry](2, eagerCancel=false))

--- a/deletescanner/src/main/scala/DeleteScanner.scala
+++ b/deletescanner/src/main/scala/DeleteScanner.scala
@@ -119,7 +119,7 @@ object DeleteScanner extends ZonedDateTimeEncoder  {
     val updateFuture = runInfo match {
       case Some(jobHistory)=>
         val updatedJobHistory = jobHistory.copy(scanFinish = Some(ZonedDateTime.now()), lastError = errorMessage)
-        jobHistoryDAO.put(updatedJobHistory).map({
+        jobHistoryDAO.updateStatusOnly(updatedJobHistory).map({
           case Left(err)=>logger.error(s"Could not update job history entry: ${err.toString}")
           case Right(newVersion)=>logger.info(s"Update run ${updatedJobHistory} with new version $newVersion")
         })

--- a/deletescanner/src/main/scala/DeleteScanner.scala
+++ b/deletescanner/src/main/scala/DeleteScanner.scala
@@ -145,12 +145,12 @@ object DeleteScanner extends ZonedDateTimeEncoder with CleanoutFunctions {
 
     lazy implicit val jobHistoryDAO = new JobHistoryDAO(esClient, jobIndexName)
 
-    cleanoutOldJobs(jobHistoryDAO, JobType.DeletedScan,leaveOpenDays).map({
+    Await.ready(cleanoutOldJobs(jobHistoryDAO, JobType.DeletedScan,leaveOpenDays).map({
       case Left(errs)=>
         logger.error(s"Cleanout of old census jobs failed: $errs")
       case Right(results)=>
         logger.info(s"Cleanout of old census jobs succeeded: $results")
-    })
+    }), 5 minutes)
 
     val runInfo = JobHistory.newRun(JobType.DeletedScan)
 

--- a/frontend/app/CurrentStateStats.jsx
+++ b/frontend/app/CurrentStateStats.jsx
@@ -191,7 +191,7 @@ class CurrentStateStats extends React.Component {
                 }
                 {this.state.lastDeleteRunSuccess ?
                     <li>Last successful deletion scan completed <TimestampDiffComponent
-                        endTime={this.state.lastRunSuccess.scanFinish}/>.</li> :
+                        endTime={this.state.lastDeleteRunSuccess.scanFinish}/>.</li> :
                     <li>There have not been any successful deletion scan runs yet!</li>
                 }
             </ul>

--- a/frontend/app/RunsInProgress.jsx
+++ b/frontend/app/RunsInProgress.jsx
@@ -22,7 +22,7 @@ class RunsInProgress extends React.Component {
     }
 
     refresh(){
-        this.setState({loading:true, lastError: null}, ()=>axios.get("/api/jobs/running").then(response=>{
+        this.setState({loading:true, lastError: null}, ()=>axios.get("/api/jobs/running?limit=10").then(response=>{
             this.setState({loading: false, lastError: null, runData: response.data.entries})
         }).catch(err=>{
             console.error(err);

--- a/nearlinescanner/src/main/scala/NearlineScanner.scala
+++ b/nearlinescanner/src/main/scala/NearlineScanner.scala
@@ -83,7 +83,7 @@ object NearlineScanner {
     val updateFuture = runInfo match {
       case Some(jobHistory)=>
         val updatedJobHistory = jobHistory.copy(scanFinish = Some(ZonedDateTime.now()), lastError = errorMessage)
-        jobHistoryDAO.put(updatedJobHistory).map({
+        jobHistoryDAO.updateStatusOnly(updatedJobHistory).map({
           case Left(err)=>logger.error(s"Could not update job history entry: ${err.toString}")
           case Right(newVersion)=>logger.info(s"Update run $updatedJobHistory with new version $newVersion")
         })


### PR DESCRIPTION
Under dployment conditions, the scanner has been getting into a tizz when VS returns 503, causing it to loop endlessly or just fail repeatedly.

I have tracked this down to the response body not being correctly handled in this case and have improved the overall handling of 503 conditions