### PR TITLE
Don't remove non-VS attributes from VSFile record during scan

### DIFF
--- a/common/src/main/scala/vidispine/VSFile.scala
+++ b/common/src/main/scala/vidispine/VSFile.scala
@@ -12,7 +12,30 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class VSFile(vsid:String, path:String, uri:String, state:Option[VSFileState.Value], size:Long, hash:Option[String],
                   timestamp:ZonedDateTime,refreshFlag:Int,storage:String, metadata:Option[Map[String,String]],
-                  membership: Option[VSFileItemMembership], archiveHunterId: Option[String])
+                  membership: Option[VSFileItemMembership], archiveHunterId: Option[String]) {
+  /**
+    * returns a Map that contains the relevant parts of the object for updating in NearlineScanner.
+    * this is to ensure that archiveHunterId does not get overwritten.
+    */
+  def partialMap() = {
+    val optionalParamMap = Seq(
+      state.map(s=>Map("state"->s)),
+      hash.map(h=>Map("hash"->h)),
+      metadata.map(m=>Map("membership"->m)),
+      membership.map(m=>Map("membership"->m)),
+    ).collect({case Some(entry)=>entry}).reduce(_ ++ _)
+
+    Map(
+      "vsid"->vsid,
+      "path"->path,
+      "uri"->uri,
+      "size"->size,
+      "timestamp"->timestamp,
+      "refreshFlag"->refreshFlag,
+      "storage"->storage
+    ) ++ optionalParamMap
+  }
+}
 
 object VSFile {
   val logger = LoggerFactory.getLogger(getClass)

--- a/common/src/test/scala/VSFileSpec.scala
+++ b/common/src/test/scala/VSFileSpec.scala
@@ -1,7 +1,7 @@
 import java.time.ZonedDateTime
 
 import org.specs2.mutable.Specification
-import vidispine.VSFile
+import vidispine.{VSFile, VSFileState}
 
 class VSFileSpec extends Specification{
   "VSFile.storageSubpath" should {
@@ -50,7 +50,8 @@ class VSFileSpec extends Specification{
         1,
         "VX-18",
         Some(Map("created"->"1558437337823","mtime"->"1558437337823")),
-        None
+        None,
+        None,
       )))
     }
 
@@ -59,6 +60,21 @@ class VSFileSpec extends Specification{
       val result = VSFile.fromXmlString(sampleFileXml)
 
       result must beSuccessfulTry(None)
+    }
+  }
+
+  "VSFile.partialMap" should {
+    "output a map that only contains the right fields" in {
+      val t = ZonedDateTime.now()
+      val toTest = VSFile("VX-1234","/path/to/file","file://path/to/file",Some(VSFileState.CLOSED),1234L,Some("hash-goes-here"),t,1,"VX-2",None,None,None)
+
+      val result = toTest.partialMap()
+      result.contains("archiveHunterId") mustEqual false
+      result.contains("membership") mustEqual false
+      result.get("vsid") must beSome("VX-1234")
+      result.get("path") must beSome("/path/to/file")
+      result.get("uri") must beSome("file://path/to/file")
+      result.get("size") must beSome(1234L)
     }
   }
 }

--- a/common/src/test/scala/VSShapeSpec.scala
+++ b/common/src/test/scala/VSShapeSpec.scala
@@ -818,14 +818,14 @@ class VSShapeSpec extends Specification with Mockito {
         Seq(
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691L,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
-            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None
+            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None,
           ),
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
-            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None),
+            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None),
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
-            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None)
+            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None)
         )
       ))
     }

--- a/nearlinescanner/src/main/scala/NearlineScanner.scala
+++ b/nearlinescanner/src/main/scala/NearlineScanner.scala
@@ -55,7 +55,7 @@ object NearlineScanner extends CleanoutFunctions {
       val src = builder.add(new VSStorageScanSource(Some(storageId), None, vsCommunicator,pageSize=100))
       val updater = builder.add(new PeriodicUpdateBasic[VSFile](initialJobRecord))
 
-      val sink = builder.add(indexer.getSink(esClient))
+      val sink = builder.add(indexer.getPartialUpdateSink(esClient))
       val splitter = builder.add(new Broadcast[VSFile](2,eagerCancel = true))
 
       src.out.log("vs-file-indexer-stream") ~> updater ~> splitter ~> sink


### PR DESCRIPTION
perform partial updates during nearline scan rather than full overwrite of records