### PR TITLE
Remove the index records for objects that have been deleted from nearline

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val `common` = (project in file("common"))
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-java8" % circeVersion,
       "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.typesafe.akka" %% "akka-agent" % akkaVersion,
       "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "com.sksamuel.elastic4s" %% "elastic4s-http" % elastic4sVersion,
@@ -90,6 +91,7 @@ lazy val `fixmissing` = (project in file("vs-fix-missing-files"))
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "org.postgresql" % "postgresql" % "42.2.5",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-agent" % akkaVersion,
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
@@ -123,6 +125,7 @@ lazy val `cronscanner` = (project in file("cronscanner"))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "org.postgresql" % "postgresql" % "42.2.5",
       "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.typesafe.akka" %% "akka-agent" % akkaVersion,
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
@@ -157,6 +160,7 @@ lazy val `deletescanner` = (project in file("deletescanner"))
     "org.postgresql" % "postgresql" % "42.2.5",
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-agent" % akkaVersion,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
@@ -190,6 +194,7 @@ lazy val `nearlinescanner` = (project in file("nearlinescanner"))
   .settings(commonSettings, libraryDependencies ++= Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-agent" % akkaVersion,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
@@ -223,6 +228,7 @@ lazy val `findarchivednearline` = (project in file("findarchivednearline"))
   .settings(commonSettings, libraryDependencies ++= Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-agent" % akkaVersion,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
@@ -256,6 +262,7 @@ lazy val `remove-archived-nearline` = (project in file("remove-archived-nearline
   .settings(commonSettings, libraryDependencies ++= Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-agent" % akkaVersion,
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
@@ -291,6 +298,7 @@ lazy val `fixorphans` = (project in file("fix-orphaned-media"))
   .settings(commonSettings, libraryDependencies ++= Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-agent" % akkaVersion,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
@@ -325,6 +333,7 @@ lazy val `archivescanner` = (project in file("archivescanner"))
   .settings(commonSettings, libraryDependencies ++= Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-agent" % akkaVersion,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
@@ -360,7 +369,8 @@ lazy val `mxscopy` = (project in file("mxs-copy-components"))
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-stream" % akkaVersion,
       "com.typesafe.akka" %% "akka-testkit" % akkaVersion,
-      "com.typesafe.akka" %% "akka-http" % "10.1.7",
+      "com.typesafe.akka" %% "akka-agent" % akkaVersion,
+        "com.typesafe.akka" %% "akka-http" % "10.1.7",
       "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "1.0.2",
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val awsSdkVersion = "1.11.346"
 
 lazy val `mediacensus` = (project in file(".")).enablePlugins(PlayScala, DockerPlugin, AshScriptPlugin)
   .dependsOn(common)
-  .aggregate(archivescanner, cronscanner, deletescanner, nearlinescanner, findarchivednearline, fixmissing, fixorphans)
+  .aggregate(archivescanner, cronscanner, deletescanner, nearlinescanner, findarchivednearline, fixmissing, fixorphans, `remove-archived-nearline`)
   .settings(version := sys.props.getOrElse("build.number","DEV"),
     dockerPermissionStrategy := DockerPermissionStrategy.Run,
     daemonUserUid in Docker := None,

--- a/build.sbt
+++ b/build.sbt
@@ -9,13 +9,13 @@ resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
 resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
 
-scalaVersion := "2.12.3"
+scalaVersion := "2.12.10"
 
 libraryDependencies ++= Seq( jdbc , ehcache , ws , specs2 % Test , guice )
 
 lazy val commonSettings = Seq(
   version := "1.0",
-  scalaVersion := "2.12.3"
+  scalaVersion := "2.12.10"
 )
 
 val awsSdkVersion = "1.11.346"

--- a/build.sbt
+++ b/build.sbt
@@ -250,6 +250,41 @@ lazy val `findarchivednearline` = (project in file("findarchivednearline"))
     )
   )
 
+lazy val `remove-archived-nearline` = (project in file("remove-archived-nearline"))
+  .enablePlugins(DockerPlugin, AshScriptPlugin)
+  .dependsOn(common)
+  .settings(commonSettings, libraryDependencies ++= Seq(
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
+    "io.circe" %% "circe-core" % circeVersion,
+    "io.circe" %% "circe-generic" % circeVersion,
+    "io.circe" %% "circe-parser" % circeVersion,
+    "io.circe" %% "circe-java8" % circeVersion,
+    "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-http" % elastic4sVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-circe" % elastic4sVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-http-streams" % elastic4sVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test",
+    "com.sksamuel.elastic4s" %% "elastic4s-embedded" % elastic4sVersion % "test",
+    specs2 % Test
+  ),version := sys.props.getOrElse("build.number","DEV"),
+    dockerPermissionStrategy := DockerPermissionStrategy.Run,
+    daemonUserUid in Docker := None,
+    daemonUser in Docker := "daemon",
+    dockerUsername  := sys.props.get("docker.username"),
+    dockerRepository := Some("guardianmultimedia"),
+    packageName in Docker := "guardianmultimedia/mediacensus-remove-archived",
+    packageName := "mediacensus-remove-archived",
+    dockerBaseImage := "openjdk:8-jdk-alpine",
+    dockerAlias := docker.DockerAlias(None,Some("guardianmultimedia"),"mediacensus-remove-archived",Some(sys.props.getOrElse("build.number","DEV"))),
+    dockerCommands ++= Seq(
+      Cmd("USER","root"),
+      Cmd("RUN", "chmod -R a+x /opt/docker"),
+      Cmd("USER", "daemon")
+    )
+  )
+
 lazy val `fixorphans` = (project in file("fix-orphaned-media"))
   .enablePlugins(DockerPlugin, AshScriptPlugin)
   .dependsOn(common, mxscopy)

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -15,7 +15,11 @@
     <logger name="streamComponents.VSFileSwitch" level="INFO"/>
     <logger name="streamComponents.VSFindReplicas" level="INFO"/>
     <logger name="vidispine.VSShape" level="INFO"/>
+    <logger name="streamComponents.FixVidispineMeta" level="DEBUG"/>
     <logger name="streamComponents.PeriodicUpdate" level="INFO"/>
+    <logger name="streamComponents.DecodeArchiveHunterId" level="WARN"/>
+    <logger name="streamComponents.LookupS3Metadata" level="WARN"/>
+    <logger name="streamComponents.VSGetItem" level="WARN"/>
     <logger name="streamComponents.AssetSweeperDeletedSource" level="INFO"/>
     <logger name="streamComponents.VSStorageScanSource" level="INFO"/>
     <logger name="models.JobHistoryDAO" level="INFO"/>
@@ -26,6 +30,7 @@
     <logger name="nlstreamcomponents" level="INFO"/>
     <logger name="vidispine.VSCommunicator" level="WARN"/>
     <logger name="archivehunter" level="INFO"/>
+    <logger name="Main" level="DEBUG"/>
 
     <root level="WARN">
         <appender-ref ref="ASYNCSTDOUT" />

--- a/common/src/main/scala/helpers/TrustStoreHelper.scala
+++ b/common/src/main/scala/helpers/TrustStoreHelper.scala
@@ -1,0 +1,144 @@
+package helpers
+import java.io.FileInputStream
+import java.security.KeyStore
+
+import javax.net.ssl.{SSLContext, TrustManager, TrustManagerFactory, X509TrustManager}
+import java.security.KeyStore
+import java.security.cert.{CertificateException, X509Certificate}
+import sun.security.ssl.SSLContextImpl
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+/**
+  * helper that builds a custom trust manager implementation that supports multiple keystores
+  * (i.e. the default one AND a custom one)
+  */
+object TrustStoreHelper {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+    * obtain an X509TrustManager object based on the Java Keystore trust store at the given file path
+    * @param keyStorePath path of a .jks file to open
+    * @return a Try with either the X509TrustManager or an error
+    */
+  def getCustomTrustManager(keyStorePath:String, passwordString:Option[String]):Try[X509TrustManager] = {
+    val myKeys = new FileInputStream(keyStorePath)
+    try {
+      // Do the same with your trust store this time
+      // Adapt how you load the keystore to your needs
+      val myTrustStore = KeyStore.getInstance(KeyStore.getDefaultType)
+      myTrustStore.load(myKeys, passwordString.map(_.toCharArray).getOrElse(null))
+
+      val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+      tmf.init(myTrustStore)
+      val trustManagerList = tmf.getTrustManagers.filter(_.isInstanceOf[X509TrustManager])
+
+      if(trustManagerList.isEmpty){
+        Failure(new RuntimeException(s"Could not find x509 trust manager in the provided store $keyStorePath"))
+      }
+
+      Success(trustManagerList.head.asInstanceOf[X509TrustManager])
+    } catch {
+      case ex:Throwable=>Failure(ex)
+    } finally {
+      myKeys.close()
+    }
+  }
+
+  /**
+    * obtain an X509TrustManager object representing the default key store
+    * @return a Try with either the X509TrustManager or an error
+    */
+  def getDefaultTrustManager:Try[X509TrustManager] = Try {
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    // Using null here initialises the TMF with the default trust store.
+    tmf.init(null.asInstanceOf[KeyStore])
+
+    val trustManagerList = tmf.getTrustManagers.filter(_.isInstanceOf[X509TrustManager])
+
+    if(trustManagerList.isEmpty){
+      throw new RuntimeException("Could not find default trust manager")
+    }
+
+    trustManagerList.head.asInstanceOf[X509TrustManager]
+  }
+
+  /**
+    * build a custom X509TrustManager that will delegate to one of a list of trust managers
+    * @param trustManagersList a sequence of subsequent trust managers to try. It's assumed that the "default" one is the first in the list.
+    * @return an X509TrustManager object
+    */
+  def customX509TrustManager(trustManagersList:Seq[X509TrustManager]) = new X509TrustManager {
+    /**
+      * checkClientTrusted delegates to defaultTrustManager only
+      * @param x509Certificates
+      * @param authType
+      * @throws
+      */
+    @throws[CertificateException]
+    override def checkClientTrusted(x509Certificates: Array[X509Certificate], authType: String): Unit = trustManagersList.head.checkClientTrusted(x509Certificates, authType)
+
+    protected def recursiveCheckAdditional(x509Certificates: Array[X509Certificate], authType: String, toCheck:X509TrustManager, tail:Seq[X509TrustManager], count:Integer):Try[Unit] = {
+      Try {
+        toCheck.checkServerTrusted(x509Certificates, authType)
+      } match {
+        case itworked @ Success(_)=>itworked
+        case failure @ Failure(err)=>
+          if(err.isInstanceOf[CertificateException]) {
+            logger.info(s"Cert auth failed at $count:", err)
+            if (tail.isEmpty)
+              Failure(err)
+            else
+              recursiveCheckAdditional(x509Certificates, authType, tail.head, tail.tail, count + 1)
+          } else {
+            failure
+          }
+      }
+    }
+
+    /**
+      * recurse through all given X509TrustManagers until we find one that passes. If none pass then fail.
+      * this is a Java method so expects an exception to be thrown if it fails
+      * @param x509Certificates certs to verify
+      * @param authType authentication type
+      */
+    @throws[CertificateException]
+    override def checkServerTrusted(x509Certificates: Array[X509Certificate], authType: String): Unit = recursiveCheckAdditional(x509Certificates,authType, trustManagersList.head, trustManagersList.tail,0) match {
+      case Success(_)=>()
+      case Failure(err)=>throw err
+    }
+
+    override def getAcceptedIssuers: Array[X509Certificate] = trustManagersList.flatMap(_.getAcceptedIssuers).toArray
+  }
+
+  /**
+    * convenience function that builds a custom TrustManager, configures an SSLContext to use it and then sets this context
+    * as the default one
+    * @param keyStorePaths sequence of paths to supplementary keystores
+    * @return
+    */
+  def setupTS(keyStorePaths:Seq[String]) = {
+    val trustManagerOrErrorList = Seq(getDefaultTrustManager) ++ keyStorePaths.map(path=>getCustomTrustManager(path,None))
+
+    val failures = trustManagerOrErrorList.collect({case Failure(err)=>err})
+    if(failures.nonEmpty){
+      failures.foreach(err=>
+      logger.error("Could not initialise trust stores: ", err)
+      )
+      Failure(failures.head)
+    } else {
+      val trustManagerList = trustManagerOrErrorList.collect({case Success(tm)=>tm})
+      val customTm = customX509TrustManager(trustManagerList)
+
+      val sslContext = SSLContext.getInstance("TLS")
+      sslContext.init(null, Array(customTm), null)
+
+      // You don't have to set this as the default context,
+      // it depends on the library you're using.
+      SSLContext.setDefault(sslContext)
+      Success(sslContext)
+    }
+  }
+}

--- a/common/src/main/scala/models/ArchiveNearlineEntryIndexer.scala
+++ b/common/src/main/scala/models/ArchiveNearlineEntryIndexer.scala
@@ -33,9 +33,13 @@ class ArchiveNearlineEntryIndexer(val indexName:String, batchSize:Int=20, concur
     Sink.fromSubscriber(esClient.subscriber[ArchiveNearlineEntry](batchSize=batchSize, concurrentRequests = concurrentBatches))
   }
 
-  def deleteSink(esClient:ElasticClient)(implicit actorRefFactory: ActorRefFactory) = {
+  def deleteSink(esClient:ElasticClient, reallyDelete:Boolean)(implicit actorRefFactory: ActorRefFactory) = {
     implicit val builder:RequestBuilder[ArchiveNearlineEntry] = (t: ArchiveNearlineEntry) => delete(t.omUri) from s"$indexName/archivenl"
-    Sink.fromSubscriber(esClient.subscriber[ArchiveNearlineEntry](batchSize=batchSize, concurrentRequests = concurrentBatches))
+    if(reallyDelete) {
+      Sink.fromSubscriber(esClient.subscriber[ArchiveNearlineEntry](batchSize = batchSize, concurrentRequests = concurrentBatches))
+    } else {
+      Sink.foreach[ArchiveNearlineEntry](elem=>logger.warn(s"I would delete ${elem.omUri} from the archive index if reallyDelete were true"))
+    }
   }
 
   /**

--- a/common/src/main/scala/models/ArchiveNearlineEntryIndexer.scala
+++ b/common/src/main/scala/models/ArchiveNearlineEntryIndexer.scala
@@ -33,6 +33,11 @@ class ArchiveNearlineEntryIndexer(val indexName:String, batchSize:Int=20, concur
     Sink.fromSubscriber(esClient.subscriber[ArchiveNearlineEntry](batchSize=batchSize, concurrentRequests = concurrentBatches))
   }
 
+  def deleteSink(esClient:ElasticClient)(implicit actorRefFactory: ActorRefFactory) = {
+    implicit val builder:RequestBuilder[ArchiveNearlineEntry] = (t: ArchiveNearlineEntry) => delete(t.omUri) from s"$indexName/archivenl"
+    Sink.fromSubscriber(esClient.subscriber[ArchiveNearlineEntry](batchSize=batchSize, concurrentRequests = concurrentBatches))
+  }
+
   /**
     * return an akka streams source for VSFile hits based on the given query parameters. You can directly .map() this to a VSFile:
     * source.map(_.as[VSFile]) provided that you have circe and the relevant elastic4s implicits in scope

--- a/common/src/main/scala/models/JobType.scala
+++ b/common/src/main/scala/models/JobType.scala
@@ -5,7 +5,7 @@ import io.circe.{Decoder, Encoder}
 object JobType extends Enumeration {
   type JobType = Value
 
-  val CensusScan, DeletedScan, NearlineScan,ArchiveHunterScan = Value
+  val CensusScan, DeletedScan, NearlineScan,ArchiveHunterScan,RemoveArchivedNearline = Value
 }
 
 trait JobTypeEncoder {

--- a/common/src/main/scala/models/VSFileIndexer.scala
+++ b/common/src/main/scala/models/VSFileIndexer.scala
@@ -62,7 +62,7 @@ class VSFileIndexer(val indexName:String, batchSize:Int=20, concurrentBatches:In
     if(reallyDelete) {
       Sink.fromSubscriber(esClient.subscriber[VSFile](batchSize = batchSize, concurrentRequests = concurrentBatches))
     } else {
-      Sink.foreach[VSFile](elem=>logger.warn(s"I would delete ${elem.path} from ${elem.storage} if reallyDelete were true"))
+      Sink.foreach[VSFile](elem=>logger.warn(s"I would delete the index record for ${elem.path} from ${elem.storage} if reallyDelete were true"))
     }
   }
 

--- a/common/src/main/scala/streamComponents/DecodeArchiveHunterId.scala
+++ b/common/src/main/scala/streamComponents/DecodeArchiveHunterId.scala
@@ -20,7 +20,7 @@ class DecodeArchiveHunterId extends GraphStage[FlowShape[VSFile,(VSFile, String,
     setHandler(in, new AbstractInHandler {
       override def onPush(): Unit = {
         val elem = grab(in)
-
+        logger.info(s"Got incoming element $elem")
         elem.archiveHunterId match {
           case None=>
             logger.error(s"The incoming item ${elem.uri} has no archivehunter id, this probably indicates a bug")
@@ -35,6 +35,7 @@ class DecodeArchiveHunterId extends GraphStage[FlowShape[VSFile,(VSFile, String,
             } else {
               val collectionName = parts.head
               val path = parts.tail.mkString(":")
+              logger.info(s"Got $collectionName and $path")
               push(out, (elem, collectionName, path))
             }
         }
@@ -42,7 +43,10 @@ class DecodeArchiveHunterId extends GraphStage[FlowShape[VSFile,(VSFile, String,
     })
 
     setHandler(out, new AbstractOutHandler {
-      override def onPull(): Unit = pull(in)
+      override def onPull(): Unit = {
+        logger.debug("pull")
+        pull(in)
+      }
     })
   }
 }

--- a/common/src/main/scala/streamComponents/DecodeArchiveHunterId.scala
+++ b/common/src/main/scala/streamComponents/DecodeArchiveHunterId.scala
@@ -1,0 +1,48 @@
+package streamComponents
+
+import java.util.Base64
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import org.slf4j.LoggerFactory
+import vidispine.VSFile
+
+class DecodeArchiveHunterId extends GraphStage[FlowShape[VSFile,(VSFile, String, String)]] {
+  private final val in:Inlet[VSFile] = Inlet.create("DecodeArchiveHunterId.in")
+  private final val out:Outlet[(VSFile,String,String)] = Outlet.create("DecodeArchiveHunterId.out")
+
+  override def shape: FlowShape[VSFile, (VSFile, String, String)] = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+    private val decoder = Base64.getDecoder
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        elem.archiveHunterId match {
+          case None=>
+            logger.error(s"The incoming item ${elem.uri} has no archivehunter id, this probably indicates a bug")
+            pull(in)
+          case Some(archiveHunterId)=>
+            val decodedId = new String(decoder.decode(archiveHunterId))
+            logger.debug(s"decoded ID is $decodedId")
+            val parts = decodedId.split(":")
+            if(parts.length<2){
+              logger.error(s"The decoded ID for ${elem.uri} ($decodedId) does not seem properly formed, not enough :")
+              pull(in)
+            } else {
+              val collectionName = parts.head
+              val path = parts.tail.mkString(":")
+              push(out, (elem, collectionName, path))
+            }
+        }
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}

--- a/common/src/main/scala/streamComponents/VSDeleteFile.scala
+++ b/common/src/main/scala/streamComponents/VSDeleteFile.scala
@@ -1,0 +1,79 @@
+import akka.NotUsed
+import akka.stream.{Attributes, FlowShape, Inlet, Materializer, Outlet, SinkShape}
+import akka.stream.scaladsl.{GraphDSL, Sink}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import org.slf4j.LoggerFactory
+import vidispine.VSCommunicator.OperationType
+import vidispine.{VSCommunicator, VSFile}
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+/**
+  * asks Vidispine to delete each VSFile instance that comes through. A failure will fail the stage (terminating the stream
+  * unless other error handling is present)
+  * @param comm implicitly provided VSCommunicator to talk to Vidispine
+  * @param mat implicitly provided ActorMaterializer
+  * @param ec implicitly provided ExecutionContext for async operations
+  */
+class VSDeleteFile(implicit comm:VSCommunicator, mat:Materializer, ec:ExecutionContext) extends GraphStage[FlowShape[VSFile,VSFile]] {
+  private final val in:Inlet[VSFile] = Inlet.create("VSDeleteFile.in")
+  private final val out:Outlet[VSFile] = Outlet.create("VSDeleteFile.out")
+
+  override def shape: FlowShape[VSFile, VSFile] = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    private val successCb = createAsyncCallback[VSFile](f=>push(out,f))
+    private val failedCb = createAsyncCallback[Throwable](err=>failStage(err))
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        val url = s"/API/file/${elem.vsid}"
+        logger.info(s"Sending DELETE request to $url...")
+        comm.request(OperationType.DELETE, url, None, Map(), Map()).onComplete({
+          case Success(Right(_))=>
+            logger.info(s"Delete completed successfully")
+            successCb.invoke(elem)
+          case Success(Left(httpError))=>
+            if(httpError.errorCode==404){
+              logger.warn(s"Tried to delete file ${elem.vsid} (${elem.path}) which was already missing!")
+              successCb.invoke(elem)
+            } else {
+              logger.error(s"Could not delete file: Vidispine returned an error ${httpError.errorCode}: ${httpError.message}")
+              failedCb.invoke(new RuntimeException(httpError.message))
+            }
+          case Failure(err)=>
+            logger.error(s"Delete operation request crashed: ", err)
+            failedCb.invoke(err)
+        })
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}
+
+object VSDeleteFile {
+  /**
+    * provdes VSDeleteFile as a Sink shape rather than a Flow shape
+    * @param comm implicitly provided [[VSCommunicator]] object
+    * @return a Sink for [[VSFile]] instances
+    */
+  def asSink(implicit comm:VSCommunicator, mat:Materializer, ec:ExecutionContext):Sink[VSFile, NotUsed] = {
+    val partialGraph = GraphDSL.create() { implicit builder=>
+      import akka.stream.scaladsl.GraphDSL.Implicits._
+      val deleteFileFlow = builder.add(new VSDeleteFile())
+      val fakeSink = Sink.ignore
+
+      deleteFileFlow ~> fakeSink
+      SinkShape(deleteFileFlow.in)
+    }
+    Sink.fromGraph(partialGraph)
+  }
+}

--- a/common/src/main/scala/streamComponents/VSFileIdInList.scala
+++ b/common/src/main/scala/streamComponents/VSFileIdInList.scala
@@ -1,0 +1,44 @@
+package streamComponents
+
+import akka.stream.{Attributes, Inlet, Outlet, UniformFanOutShape}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import org.slf4j.LoggerFactory
+import vidispine.VSFile
+
+/**
+  * pushes the provided VSFile to "yes" if its ID is in the string list provided at construction or pushes it to
+  * "no" if it isn't
+  * @param fileIdList a sequence of strings to match against
+  */
+class VSFileIdInList(fileIdList:Seq[String]) extends GraphStage[UniformFanOutShape[VSFile, VSFile]] {
+  private final val in:Inlet[VSFile] = Inlet.create("VSFileIdInList.in")
+  private final val yes:Outlet[VSFile] = Outlet.create("VSFileIdInList.yes")
+  private final val no:Outlet[VSFile] = Outlet.create("VSFileIdInList.no")
+
+  override def shape: UniformFanOutShape[VSFile, VSFile] = new UniformFanOutShape[VSFile, VSFile](in, Array(yes,no))
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger:org.slf4j.Logger = LoggerFactory.getLogger(getClass)
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        if(fileIdList.contains(elem.vsid)){
+          logger.debug(s"File ${elem.vsid} (${elem.path}) exists in match list")
+          push(yes, elem)
+        } else {
+          logger.debug(s"File ${elem.vsid} (${elem.path}) does not exist in match list")
+          push(no, elem)
+        }
+      }
+    })
+
+    val genericOutHandler = new AbstractOutHandler {
+      override def onPull(): Unit = if(!hasBeenPulled(in)) pull(in)
+    }
+
+    setHandler(yes, genericOutHandler)
+    setHandler(no, genericOutHandler)
+  }
+}

--- a/common/src/main/scala/streamComponents/VSGetItem.scala
+++ b/common/src/main/scala/streamComponents/VSGetItem.scala
@@ -1,0 +1,48 @@
+package streamComponents
+
+import akka.stream.{Attributes, FlowShape, Inlet, Materializer, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import org.slf4j.LoggerFactory
+import vidispine.{VSCommunicator, VSFile, VSLazyItem}
+
+import scala.concurrent.ExecutionContext
+
+class VSGetItem(fieldList:Seq[String])(implicit comm:VSCommunicator, mat:Materializer, ec:ExecutionContext) extends GraphStage[FlowShape[VSFile, (VSFile, Option[VSLazyItem])]] {
+  private final val in:Inlet[VSFile] = Inlet.create("VSGetItem.in")
+  private final val out:Outlet[(VSFile, Option[VSLazyItem])] = Outlet.create("VSGetItem.out")
+
+  override def shape = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        val completedCb = createAsyncCallback[Option[VSLazyItem]](itm=>(elem,itm))
+        val failedCb = createAsyncCallback[Throwable](err=>failStage(err))
+
+        elem.membership match {
+          case Some(fileItemMembership)=>
+            val item = VSLazyItem(fileItemMembership.itemId)
+            item.getMoreMetadata(fieldList).map({
+              case Left(metadataError)=>
+                logger.error(s"Could not get metadata for item ${fileItemMembership.itemId}: $metadataError")
+                failedCb.invoke(new RuntimeException("Could not lookup metadata"))
+              case Right(updatedItem)=>
+                logger.debug(s"Looked up metadata for item ${updatedItem.itemId}")
+                completedCb.invoke(Some(updatedItem))
+            })
+          case None=>
+            logger.warn(s"Can't look up item metadata for file ${elem.vsid} as it is not a member of any item")
+            completedCb.invoke(None)
+        }
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}

--- a/common/src/main/scala/vidispine/ArchivalMetadata.scala
+++ b/common/src/main/scala/vidispine/ArchivalMetadata.scala
@@ -1,0 +1,133 @@
+package vidispine
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+import akka.stream.Materializer
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.xml.NodeSeq
+
+case class ArchivalMetadata(committedAt:ZonedDateTime, externalArchiveDevice:String, externalArchiveRequest:String,
+                            externalArchiveReport:String,externalArchiveStatus:String,externalArchivePath:String,
+                            externalArchiveDeleteShape:Boolean,externalArchiveProblems:Option[String]) {
+  import ArchivalMetadata._
+  /**
+    * make an XML document for the given metadata
+    * @return
+    */
+  def makeXml:NodeSeq  = {
+    <group name="ExternalArchiveRequest">
+      <field name="gnm_external_archive_committed_to_archive_at">
+        <value>${committedAt.format(ArchivalMetadata.vidispineDateFormat)}</value>
+      </field>
+      <field name="gnm_external_archive_external_archive_device">
+        <value>${externalArchiveDevice}</value>
+      </field>
+      <field name="gnm_external_archive_external_archive_request">
+        <value>${externalArchiveRequest}</value>
+      </field>
+      <field name="gnm_external_archive_external_archive_report">
+        <value>${externalArchiveReport}</value>
+      </field>
+      <field name="gnm_external_archive_external_archive_status">
+        <value>${externalArchiveStatus}</value>
+      </field>
+      <field name="gnm_external_archive_external_archive_path">
+        <value>${externalArchivePath}</value>
+      </field>
+      <field name="gnm_external_archive_delete_shape">
+        <value>${if(externalArchiveDeleteShape) "true" else "false"}</value>
+      </field>
+      ${externalArchiveProblems.map(probsValue=>
+        <field name="gnm_external_archive_problems">
+          <value>${probsValue}</value>
+        </field>
+    )}
+    </group>
+  }
+
+  /**
+    * check that the status field is set to an acceptable value
+    * @return a Boolean, true if it's ok
+    */
+  def validateStatus: Boolean =
+    externalArchiveStatus==AS_NONE || externalArchiveStatus==AS_RUNNING || externalArchiveStatus==AS_FAILED ||
+    externalArchiveStatus==AS_VERIFYING || externalArchiveStatus==AS_ARCHIVED
+
+  def validateRequest:Boolean =
+    externalArchiveRequest==AR_NONE || externalArchiveRequest==AR_REQUESTED || externalArchiveRequest==AR_REQUESTEDRESTORE
+
+}
+
+object ArchivalMetadata {
+  val interestingFields = Seq(
+    "gnm_external_archive_committed_to_archive_at",
+    "gnm_external_archive_external_archive_device",
+    "gnm_external_archive_external_archive_request",
+    "gnm_external_archive_external_archive_report",
+    "gnm_external_archive_external_archive_status",
+    "gnm_external_archive_external_archive_path",
+    "gnm_external_archive_delete_shape",
+    "gnm_external_archive_problems"
+  )
+
+  //ExternalArchiveRequest values
+  val AR_NONE = "None"
+  val AR_REQUESTED = "Requested Archive"
+  val AR_REQUESTEDRESTORE = "Requested Restore"
+
+  //ExternalArchiveStatus values
+  val AS_NONE = "Not In External Archive"
+  val AS_RUNNING = "Upload in Progress"
+  val AS_FAILED = "Upload Failed"
+  val AS_VERIFYING = "Awaiting Verification"
+  val AS_ARCHIVED = "Archived"
+
+  val vidispineDateFormat = DateTimeFormatter.ISO_DATE_TIME
+
+  private def boolFromString(str: String): Boolean = {
+    val toCheck = str.toLowerCase
+    if(toCheck=="true") true else false
+  }
+
+  /**
+    * fetch the required fields onto the given VSLazyItem.  Use this if you want to keep the updated item around
+    * @param initialItem
+    * @param comm
+    * @param mat
+    * @return
+    */
+  def fetchForItem(initialItem:VSLazyItem)(implicit comm:VSCommunicator, mat:Materializer) =
+    initialItem.getMoreMetadata(interestingFields)
+
+  /**
+    * returns ArchivalMetadata for the given VSLazyItem. Can optionally ensure that data is fetched beforehand; if you don't care
+    * about keeping the updated VSLazyItem around then call this with alwaysFetch=true. Otherwise, call `fetchForItem` first and then
+    * pass the provided lazyItem onto this method
+    * @param initialItem item to convert
+    * @param alwaysFetch if true, call out to VS to fetch required fields. If false, assume that they are present
+    * @param comm implicitly provided VSCommunicator
+    * @param mat implicitly provided Materializer
+    * @param ec implicitly provided ExecutionContext
+    * @return a Future with either a GetMetadataError or ArchivalMetadata
+    */
+  def fromLazyItem(initialItem:VSLazyItem, alwaysFetch:Boolean=false)(implicit comm:VSCommunicator, mat:Materializer, ec:ExecutionContext) = {
+    val maybeActualItem = if(alwaysFetch){
+      fetchForItem(initialItem)
+    } else {
+      Future(Right(initialItem))
+    }
+
+    maybeActualItem.map(_.map(item=>new ArchivalMetadata(
+      ZonedDateTime.parse(item.getSingle("gnm_external_archive_committed_to_archive_at").get),
+      item.getSingle("gnm_external_archive_external_archive_device").get,
+      item.getSingle("gnm_external_archive_external_archive_request").get,
+      item.getSingle("gnm_external_archive_external_archive_report").get,
+      item.getSingle("gnm_external_archive_external_archive_status").get,
+      item.getSingle("gnm_external_archive_external_archive_path").get,
+      boolFromString(item.getSingle("gnm_external_archive_delete_shape").get),
+      item.getSingle("gnm_external_archive_problems")
+    )))
+  }
+}

--- a/common/src/main/scala/vidispine/ArchivalMetadata.scala
+++ b/common/src/main/scala/vidispine/ArchivalMetadata.scala
@@ -25,7 +25,8 @@ case class ArchivalMetadata(committedAt:Option[ZonedDateTime], externalArchiveDe
     * @return
     */
   def makeXml:NodeSeq  = {
-    <group name="ExternalArchiveRequest">
+    <group>
+      <name>ExternalArchiveRequest</name>
       {committedAt.map(value=>makeXmlBlock("gnm_external_archive_committed_to_archive_at",value.format(ArchivalMetadata.vidispineDateFormat))).getOrElse(NodeSeq.Empty)}
       {externalArchiveDevice.map(value=>makeXmlBlock("gnm_external_archive_external_archive_device", value)).getOrElse(NodeSeq.Empty)}
       {externalArchiveRequest.map(value=>makeXmlBlock("gnm_external_archive_external_archive_request",value)).getOrElse(NodeSeq.Empty)}
@@ -33,12 +34,14 @@ case class ArchivalMetadata(committedAt:Option[ZonedDateTime], externalArchiveDe
       {externalArchiveStatus.map(value=>makeXmlBlock("gnm_external_archive_external_archive_status", value)).getOrElse(NodeSeq.Empty)}
       {externalArchivePath.map(value=>makeXmlBlock("gnm_external_archive_external_archive_path", value)).getOrElse(NodeSeq.Empty)}
       {externalArchiveDeleteShape.map(deleteValue=>
-        <field name="gnm_external_archive_delete_shape">
+        <field>
+          <name>gnm_external_archive_delete_shape</name>
           <value>{if(deleteValue) "true" else "false"}</value>
         </field>
       ).getOrElse(NodeSeq.Empty)}
       {externalArchiveProblems.map(probsValue=>
-        <field name="gnm_external_archive_problems">
+        <field>
+          <name>gnm_external_archive_problems</name>
           <value>{probsValue}</value>
         </field>
       ).getOrElse(NodeSeq.Empty)}
@@ -82,7 +85,7 @@ object ArchivalMetadata {
   val AS_VERIFYING = "Awaiting Verification"
   val AS_ARCHIVED = "Archived"
 
-  val vidispineDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ")
+  val vidispineDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX")
 
   private def boolFromString(str: String): Boolean = {
     val toCheck = str.toLowerCase

--- a/common/src/main/scala/vidispine/VSFile.scala
+++ b/common/src/main/scala/vidispine/VSFile.scala
@@ -12,27 +12,27 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class VSFile(vsid:String, path:String, uri:String, state:Option[VSFileState.Value], size:Long, hash:Option[String],
                   timestamp:ZonedDateTime,refreshFlag:Int,storage:String, metadata:Option[Map[String,String]],
-                  membership: Option[VSFileItemMembership], archiveHunterId: Option[String]) {
+                  membership: Option[VSFileItemMembership], archiveHunterId: Option[String], archiveConflict:Option[Boolean]=None) {
   /**
     * returns a Map that contains the relevant parts of the object for updating in NearlineScanner.
     * this is to ensure that archiveHunterId does not get overwritten.
     */
   def partialMap() = {
     val optionalParamMap = Seq(
-      state.map(s=>Map("state"->s)),
-      hash.map(h=>Map("hash"->h)),
-      metadata.map(m=>Map("membership"->m)),
-      membership.map(m=>Map("membership"->m)),
-    ).collect({case Some(entry)=>entry}).reduce(_ ++ _)
+      state.map(s => Map("state" -> s)),
+      hash.map(h => Map("hash" -> h)),
+      metadata.map(m => Map("membership" -> m)),
+      membership.map(m => Map("membership" -> m)),
+    ).collect({ case Some(entry) => entry }).reduce(_ ++ _)
 
     Map(
-      "vsid"->vsid,
-      "path"->path,
-      "uri"->uri,
-      "size"->size,
-      "timestamp"->timestamp,
-      "refreshFlag"->refreshFlag,
-      "storage"->storage
+      "vsid" -> vsid,
+      "path" -> path,
+      "uri" -> uri,
+      "size" -> size,
+      "timestamp" -> timestamp,
+      "refreshFlag" -> refreshFlag,
+      "storage" -> storage
     ) ++ optionalParamMap
   }
 }
@@ -75,6 +75,7 @@ object VSFile {
           case Success(membership) => membership
           case Failure(err) => throw err
         }),
+        None,
         None
       ),
       )

--- a/common/src/main/scala/vidispine/VSFile.scala
+++ b/common/src/main/scala/vidispine/VSFile.scala
@@ -21,7 +21,7 @@ case class VSFile(vsid:String, path:String, uri:String, state:Option[VSFileState
     val optionalParamMap = Seq(
       state.map(s => Map("state" -> s)),
       hash.map(h => Map("hash" -> h)),
-      metadata.map(m => Map("membership" -> m)),
+      metadata.map(m => Map("metadata" -> m)),
       membership.map(m => Map("membership" -> m)),
     ).collect({ case Some(entry) => entry }).reduce(_ ++ _)
 

--- a/common/src/main/scala/vidispine/VSFile.scala
+++ b/common/src/main/scala/vidispine/VSFile.scala
@@ -69,7 +69,9 @@ object VSFile {
         (xmlNode \ "storage").text,
         metadataDictFromNodes(xmlNode \ "metadata") match {
           case Success(mdDict) => Some(mdDict)
-          case Failure(err) => None
+          case Failure(err) =>
+            logger.warn(s"Could not get metadata from ${xmlNode.toString}, continuing without", err)
+            None
         },
         (xmlNode \ "item").headOption.map(node => VSFileItemMembership.fromXml(node) match {
           case Success(membership) => membership

--- a/common/src/main/scala/vidispine/VSFileItemMembership.scala
+++ b/common/src/main/scala/vidispine/VSFileItemMembership.scala
@@ -3,7 +3,7 @@ package vidispine
 import scala.util.{Failure, Success, Try}
 import scala.xml.NodeSeq
 
-case class VSFileItemMembership (itemId:String, shapes:Seq[VSFileShapeMembership])
+case class VSFileItemMembership (itemId:Option[String], shapes:Seq[VSFileShapeMembership])
 
 case class VSFileShapeMembership(shapeId:String,componentId:Seq[String])
 

--- a/common/src/main/scala/vidispine/VSFileItemMembership.scala
+++ b/common/src/main/scala/vidispine/VSFileItemMembership.scala
@@ -3,7 +3,7 @@ package vidispine
 import scala.util.{Failure, Success, Try}
 import scala.xml.NodeSeq
 
-case class VSFileItemMembership (itemId:Option[String], shapes:Seq[VSFileShapeMembership])
+case class VSFileItemMembership (itemId:String, shapes:Seq[VSFileShapeMembership])
 
 case class VSFileShapeMembership(shapeId:String,componentId:Seq[String])
 

--- a/common/src/main/scala/vidispine/VSLazyItem.scala
+++ b/common/src/main/scala/vidispine/VSLazyItem.scala
@@ -53,6 +53,16 @@ case class VSLazyItem (itemId:String, lookedUpMetadata:Map[String,VSMetadataEntr
   def getSingle(fieldName:String):Option[String] = {
     get(fieldName).flatMap(_.headOption)
   }
+
+  def toXmlDoc(rootGroup:Option[String]):Node = {
+    <MetadataDocument xmlns="http://xml.vidispine.com/schema/vidispine">
+      lookedUpMetadata.map(mdTuple=>{
+      <field name="${mdTuple._1}">
+        mdTuple._2.toSimpleXml()
+      </field>
+      }
+    </MetadataDocument>
+  }
 }
 
 object VSLazyItem extends ((String,Map[String,VSMetadataEntry],Option[Map[String,VSShape]])=>VSLazyItem) {

--- a/common/src/main/scala/vidispine/VSMetadataEntry.scala
+++ b/common/src/main/scala/vidispine/VSMetadataEntry.scala
@@ -7,7 +7,11 @@ import scala.util.{Success,Failure, Try}
 import scala.xml.NodeSeq
 
 case class VSMetadataValue(value:String, uuid:Option[UUID], user:Option[String], timestamp:Option[ZonedDateTime], change:Option[String])
-case class VSMetadataEntry(name:String, uuid:Option[UUID], user:Option[String], timestamp:Option[ZonedDateTime], change:Option[String], values:Seq[VSMetadataValue])
+case class VSMetadataEntry(name:String, uuid:Option[UUID], user:Option[String], timestamp:Option[ZonedDateTime], change:Option[String], values:Seq[VSMetadataValue]) {
+  def toSimpleXml():NodeSeq = {
+    values.map(v=>{<value>${v.value}</value>})
+  }
+}
 
 object VSMetadataEntry {
   def safeUuidString(str:String,xml:NodeSeq):Option[UUID] = Try {

--- a/common/src/test/scala/ArchivalMetadataSpec.scala
+++ b/common/src/test/scala/ArchivalMetadataSpec.scala
@@ -1,0 +1,126 @@
+import java.time.{ZoneId, ZonedDateTime}
+
+import akka.stream.Materializer
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import vidispine.{ArchivalMetadata, GetMetadataError, VSCommunicator, VSLazyItem}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class ArchivalMetadataSpec extends Specification with Mockito {
+  "ArchivalMetadata.fetchForItem" should {
+    "call out to the item to populate metadata" in {
+      implicit val fakeComm = mock[VSCommunicator]
+      implicit val fakeMat = mock[Materializer]
+
+      val mockedItem = mock[VSLazyItem]
+      val mockedUpdatedItem = mock[VSLazyItem]
+
+      mockedItem.getMoreMetadata(any)(any, any) returns Future(Right(mockedUpdatedItem))
+
+      val result = Await.result(ArchivalMetadata.fetchForItem(mockedItem), 1 seconds)
+
+      result must beRight(mockedUpdatedItem)
+      there was one(mockedItem).getMoreMetadata(ArchivalMetadata.interestingFields)
+    }
+  }
+
+  "ArchivalMetadata.fromLazyItem" should {
+    "optionally populate the metadata for an item and translate it" in {
+      implicit val fakeComm = mock[VSCommunicator]
+      implicit val fakeMat = mock[Materializer]
+
+      val mockedItem = mock[VSLazyItem]
+      val mockedUpdatedItem = mock[VSLazyItem]
+
+      mockedUpdatedItem.getSingle(any) returns (
+        Some("2019-01-02T03:04:05Z[UTC]"),
+        Some("somedevice"),
+        Some(ArchivalMetadata.AR_NONE),
+        Some(""),
+        Some(ArchivalMetadata.AS_FAILED),
+        Some("path/to/content"),
+        Some("true"),
+        None
+      )
+      mockedItem.getMoreMetadata(any)(any,any) returns Future(Right(mockedUpdatedItem))
+
+      val result = Await.result(ArchivalMetadata.fromLazyItem(mockedItem,alwaysFetch=true), 1 second)
+
+      result must beRight(ArchivalMetadata(
+        ZonedDateTime.of(2019,1,2,3,4,5,0,ZoneId.of("UTC")),
+        "somedevice",
+        ArchivalMetadata.AR_NONE,
+        "",
+        ArchivalMetadata.AS_FAILED,
+        "path/to/content",
+        true,
+        None
+      ))
+
+      there was one(mockedItem).getMoreMetadata(any)(any,any)
+    }
+
+    "optionally not populate the metadata for an item but still translate it" in {
+      implicit val fakeComm = mock[VSCommunicator]
+      implicit val fakeMat = mock[Materializer]
+
+      val mockedItem = mock[VSLazyItem]
+      val mockedUpdatedItem = mock[VSLazyItem]
+
+      mockedItem.getSingle(any) returns (
+        Some("2019-01-02T03:04:05Z[UTC]"),
+        Some("somedevice"),
+        Some(ArchivalMetadata.AR_NONE),
+        Some(""),
+        Some(ArchivalMetadata.AS_FAILED),
+        Some("path/to/content"),
+        Some("true"),
+        None
+      )
+
+      val result = Await.result(ArchivalMetadata.fromLazyItem(mockedItem,alwaysFetch=false), 1 second)
+
+      result must beRight(ArchivalMetadata(
+        ZonedDateTime.of(2019,1,2,3,4,5,0,ZoneId.of("UTC")),
+        "somedevice",
+        ArchivalMetadata.AR_NONE,
+        "",
+        ArchivalMetadata.AS_FAILED,
+        "path/to/content",
+        true,
+        None
+      ))
+
+      there was no(mockedItem).getMoreMetadata(any)(any,any)
+    }
+
+    "pass on a lookup error" in {
+      implicit val fakeComm = mock[VSCommunicator]
+      implicit val fakeMat = mock[Materializer]
+
+      val mockedItem = mock[VSLazyItem]
+      val mockedUpdatedItem = mock[VSLazyItem]
+
+      mockedUpdatedItem.getSingle(any) returns (
+        Some("2019-01-02T03:04:05Z[UTC]"),
+        Some("somedevice"),
+        Some(ArchivalMetadata.AR_NONE),
+        Some(""),
+        Some(ArchivalMetadata.AS_FAILED),
+        Some("path/to/content"),
+        Some("true"),
+        None
+      )
+      mockedItem.getMoreMetadata(any)(any, any) returns Future(Left(GetMetadataError(None,None,None)))
+
+      val result = Await.result(ArchivalMetadata.fromLazyItem(mockedItem,alwaysFetch=true), 1 second)
+
+      result must beLeft(GetMetadataError(None,None,None))
+
+      there was one(mockedItem).getMoreMetadata(any)(any,any)
+    }
+  }
+}

--- a/common/src/test/scala/ArchivalMetadataSpec.scala
+++ b/common/src/test/scala/ArchivalMetadataSpec.scala
@@ -143,7 +143,7 @@ class ArchivalMetadataSpec extends Specification with Mockito {
       val fields = result \ "field"
       val committedNode = fields.head
       (committedNode \ "name").text mustEqual "gnm_external_archive_committed_to_archive_at"
-      (committedNode \ "value").text mustEqual "2019-01-02T03:04:05+0000"
+      (committedNode \ "value").text mustEqual "2019-01-02T03:04:05Z"
 
       val deviceNode = fields(1)
       (deviceNode \ "name").text mustEqual "gnm_external_archive_external_archive_device"

--- a/common/src/test/scala/ArchivalMetadataSpec.scala
+++ b/common/src/test/scala/ArchivalMetadataSpec.scala
@@ -39,7 +39,7 @@ class ArchivalMetadataSpec extends Specification with Mockito {
         Some("2019-01-02T03:04:05Z[UTC]"),
         Some("somedevice"),
         Some(ArchivalMetadata.AR_NONE),
-        Some(""),
+        None,
         Some(ArchivalMetadata.AS_FAILED),
         Some("path/to/content"),
         Some("true"),
@@ -50,13 +50,13 @@ class ArchivalMetadataSpec extends Specification with Mockito {
       val result = Await.result(ArchivalMetadata.fromLazyItem(mockedItem,alwaysFetch=true), 1 second)
 
       result must beRight(ArchivalMetadata(
-        ZonedDateTime.of(2019,1,2,3,4,5,0,ZoneId.of("UTC")),
-        "somedevice",
-        ArchivalMetadata.AR_NONE,
-        "",
-        ArchivalMetadata.AS_FAILED,
-        "path/to/content",
-        true,
+        Some(ZonedDateTime.of(2019,1,2,3,4,5,0,ZoneId.of("UTC"))),
+        Some("somedevice"),
+        Some(ArchivalMetadata.AR_NONE),
+        None,
+        Some(ArchivalMetadata.AS_FAILED),
+        Some("path/to/content"),
+        Some(true),
         None
       ))
 
@@ -74,7 +74,7 @@ class ArchivalMetadataSpec extends Specification with Mockito {
         Some("2019-01-02T03:04:05Z[UTC]"),
         Some("somedevice"),
         Some(ArchivalMetadata.AR_NONE),
-        Some(""),
+        None,
         Some(ArchivalMetadata.AS_FAILED),
         Some("path/to/content"),
         Some("true"),
@@ -84,13 +84,13 @@ class ArchivalMetadataSpec extends Specification with Mockito {
       val result = Await.result(ArchivalMetadata.fromLazyItem(mockedItem,alwaysFetch=false), 1 second)
 
       result must beRight(ArchivalMetadata(
-        ZonedDateTime.of(2019,1,2,3,4,5,0,ZoneId.of("UTC")),
-        "somedevice",
-        ArchivalMetadata.AR_NONE,
-        "",
-        ArchivalMetadata.AS_FAILED,
-        "path/to/content",
-        true,
+        Some(ZonedDateTime.of(2019,1,2,3,4,5,0,ZoneId.of("UTC"))),
+        Some("somedevice"),
+        Some(ArchivalMetadata.AR_NONE),
+        None,
+        Some(ArchivalMetadata.AS_FAILED),
+        Some("path/to/content"),
+        Some(true),
         None
       ))
 
@@ -121,6 +121,37 @@ class ArchivalMetadataSpec extends Specification with Mockito {
       result must beLeft(GetMetadataError(None,None,None))
 
       there was one(mockedItem).getMoreMetadata(any)(any,any)
+    }
+  }
+
+  "ArchivalMetadata.makeXML" should {
+    "render out XML with only the set fields in it" in {
+      val toTest = ArchivalMetadata(
+        Some(ZonedDateTime.of(2019,1,2,3,4,5,0,ZoneId.systemDefault())),
+        Some("somedevice"),
+        Some(ArchivalMetadata.AR_REQUESTED),
+        None,
+        Some(ArchivalMetadata.AS_RUNNING),
+        Some("path/to/somefile"),
+        Some(true),
+        None
+      )
+
+      val result = toTest.makeXml
+      println(s"Got $result")
+
+      val fields = result \ "field"
+      val committedNode = fields.head
+      (committedNode \ "name").text mustEqual "gnm_external_archive_committed_to_archive_at"
+      (committedNode \ "value").text mustEqual "2019-01-02T03:04:05+0000"
+
+      val deviceNode = fields(1)
+      (deviceNode \ "name").text mustEqual "gnm_external_archive_external_archive_device"
+      (deviceNode \ "value").text mustEqual "somedevice"
+
+      val requestNode = fields(2)
+      (requestNode \ "name").text mustEqual "gnm_external_archive_external_archive_request"
+      (requestNode \ "value").text mustEqual "Requested Archive"
     }
   }
 }

--- a/common/src/test/scala/DecodeArchiveHunterIdSpec.scala
+++ b/common/src/test/scala/DecodeArchiveHunterIdSpec.scala
@@ -16,7 +16,8 @@ class DecodeArchiveHunterIdSpec extends Specification {
       implicit val mat:Materializer = ActorMaterializer.create(system)
       val fakeRecord = VSFile("VX-1234","/some/path","file://some/path",None,1234L,None,
         ZonedDateTime.now,1,"VX-23",None,None,
-        Some("Z25tLW11bHRpbWVkaWEtZGVlcGFyY2hpdmU6TXVsdGltZWRpYV9OZXdzL1RvcF90ZW5fdmlyYWxfYW5pbWFsX3ZpZGVvc19vZl8yMDE1L2phbWVzX2J1bGxvY2tfVG9wX3Rlbl92aXJhbF9hbmltYWxfdmlkZW9zX29mXzIwMTUvQWRvYmUgUHJlbWllcmUgUHJvIEF1dG8tU2F2ZS9LUC00OTYwLTUucHJwcm9q"))
+        Some("Z25tLW11bHRpbWVkaWEtZGVlcGFyY2hpdmU6TXVsdGltZWRpYV9OZXdzL1RvcF90ZW5fdmlyYWxfYW5pbWFsX3ZpZGVvc19vZl8yMDE1L2phbWVzX2J1bGxvY2tfVG9wX3Rlbl92aXJhbF9hbmltYWxfdmlkZW9zX29mXzIwMTUvQWRvYmUgUHJlbWllcmUgUHJvIEF1dG8tU2F2ZS9LUC00OTYwLTUucHJwcm9q"),
+        None)
 
       val sinkFactory = Sink.fold[Seq[(VSFile,String,String)],(VSFile,String,String)](Seq())((acc,elem)=>acc:+elem)
 

--- a/common/src/test/scala/DecodeArchiveHunterIdSpec.scala
+++ b/common/src/test/scala/DecodeArchiveHunterIdSpec.scala
@@ -1,0 +1,41 @@
+import java.time.ZonedDateTime
+
+import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
+import org.specs2.mutable.Specification
+import streamComponents.DecodeArchiveHunterId
+import testhelpers.AkkaTestkitSpecs2Support
+import vidispine.VSFile
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class DecodeArchiveHunterIdSpec extends Specification {
+  "DecodeArchiveHunterId" should {
+    "decode the given ID and push it to the output" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+      val fakeRecord = VSFile("VX-1234","/some/path","file://some/path",None,1234L,None,
+        ZonedDateTime.now,1,"VX-23",None,None,
+        Some("Z25tLW11bHRpbWVkaWEtZGVlcGFyY2hpdmU6TXVsdGltZWRpYV9OZXdzL1RvcF90ZW5fdmlyYWxfYW5pbWFsX3ZpZGVvc19vZl8yMDE1L2phbWVzX2J1bGxvY2tfVG9wX3Rlbl92aXJhbF9hbmltYWxfdmlkZW9zX29mXzIwMTUvQWRvYmUgUHJlbWllcmUgUHJvIEF1dG8tU2F2ZS9LUC00OTYwLTUucHJwcm9q"))
+
+      val sinkFactory = Sink.fold[Seq[(VSFile,String,String)],(VSFile,String,String)](Seq())((acc,elem)=>acc:+elem)
+
+      val graph = GraphDSL.create(sinkFactory) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(Source.single(fakeRecord))
+        val toTest = builder.add(new DecodeArchiveHunterId)
+
+        src ~> toTest ~> sink
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 30 seconds)
+      result.length mustEqual 1
+
+      result.head._1 mustEqual fakeRecord
+      result.head._2 mustEqual "gnm-multimedia-deeparchive"
+      result.head._3 mustEqual "Multimedia_News/Top_ten_viral_animal_videos_of_2015/james_bullock_Top_ten_viral_animal_videos_of_2015/Adobe Premiere Pro Auto-Save/KP-4960-5.prproj"
+    }
+  }
+}

--- a/common/src/test/scala/VSDeleteFileSpec.scala
+++ b/common/src/test/scala/VSDeleteFileSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import testhelpers.AkkaTestkitSpecs2Support
 import vidispine.VSCommunicator.OperationType
-import vidispine.{GetMetadataError, VSCommunicator, VSFile}
+import vidispine.{VSCommunicator, VSFile}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/common/src/test/scala/VSDeleteFileSpec.scala
+++ b/common/src/test/scala/VSDeleteFileSpec.scala
@@ -1,0 +1,101 @@
+import java.time.ZonedDateTime
+
+import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
+import models.HttpError
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import testhelpers.AkkaTestkitSpecs2Support
+import vidispine.VSCommunicator.OperationType
+import vidispine.{GetMetadataError, VSCommunicator, VSFile}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.Try
+
+class VSDeleteFileSpec extends Specification with Mockito {
+  "VSDeleteFile" should {
+    "send a DELETE request to the relevant URI when it receives a file" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+      implicit val mockedVSCommunicator = mock[VSCommunicator]
+      mockedVSCommunicator.request(any,any,any,any,any,any)(any,any) returns Future(Right(""))
+
+      val initialFile = VSFile("VX-1234","path/to/file","file://path/to/file",None,1234L,None,ZonedDateTime.now(),0,"VX-1",None,None,None,None)
+      val sinkFact = Sink.seq[VSFile]
+      val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+        val src = Source.single(initialFile)
+        val toTest = builder.add(new VSDeleteFile())
+
+        src ~> toTest ~> sink
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 10 seconds)
+      there was one(mockedVSCommunicator).request(OperationType.DELETE,"/API/file/VX-1234",None,Map(),Map())
+    }
+
+    "not fail if a 404 is returned" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+      implicit val mockedVSCommunicator = mock[VSCommunicator]
+      mockedVSCommunicator.request(any,any,any,any,any,any)(any,any) returns Future(Left(HttpError("Not found", 404)))
+
+      val initialFile = VSFile("VX-1234","path/to/file","file://path/to/file",None,1234L,None,ZonedDateTime.now(),0,"VX-1",None,None,None,None)
+      val sinkFact = Sink.seq[VSFile]
+      val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+        val src = Source.single(initialFile)
+        val toTest = builder.add(new VSDeleteFile())
+
+        src ~> toTest ~> sink
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 10 seconds)
+      there was one(mockedVSCommunicator).request(OperationType.DELETE,"/API/file/VX-1234",None,Map(),Map())
+    }
+
+    "fail if the server returns an error" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+      implicit val mockedVSCommunicator = mock[VSCommunicator]
+      mockedVSCommunicator.request(any,any,any,any,any,any)(any,any) returns Future(Left(HttpError("Kaboom", 500)))
+
+      val initialFile = VSFile("VX-1234","path/to/file","file://path/to/file",None,1234L,None,ZonedDateTime.now(),0,"VX-1",None,None,None,None)
+      val sinkFact = Sink.seq[VSFile]
+      val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+        val src = Source.fromIterator(()=>Seq(initialFile,initialFile).toIterator)
+        val toTest = builder.add(new VSDeleteFile())
+
+        src ~> toTest ~> sink
+        ClosedShape
+      }
+
+      val result = Try { Await.result(RunnableGraph.fromGraph(graph).run(), 10 seconds) }
+      there was one(mockedVSCommunicator).request(OperationType.DELETE,"/API/file/VX-1234",None,Map(),Map())
+      result must beFailedTry
+    }
+
+    "fail if the lookup future fails" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+      implicit val mockedVSCommunicator = mock[VSCommunicator]
+      mockedVSCommunicator.request(any,any,any,any,any,any)(any,any) returns Future.failed(new RuntimeException("kaboom"))
+
+      val initialFile = VSFile("VX-1234","path/to/file","file://path/to/file",None,1234L,None,ZonedDateTime.now(),0,"VX-1",None,None,None,None)
+      val sinkFact = Sink.seq[VSFile]
+      val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+        val src = Source.fromIterator(()=>Seq(initialFile,initialFile).toIterator)
+        val toTest = builder.add(new VSDeleteFile())
+
+        src ~> toTest ~> sink
+        ClosedShape
+      }
+
+      val result = Try { Await.result(RunnableGraph.fromGraph(graph).run(), 10 seconds) }
+      there was one(mockedVSCommunicator).request(OperationType.DELETE,"/API/file/VX-1234",None,Map(),Map())
+      result must beFailedTry
+    }
+  }
+}

--- a/common/src/test/scala/VSFileSpec.scala
+++ b/common/src/test/scala/VSFileSpec.scala
@@ -51,7 +51,7 @@ class VSFileSpec extends Specification{
         "VX-18",
         Some(Map("created"->"1558437337823","mtime"->"1558437337823")),
         None,
-        None,
+        None
       )))
     }
 

--- a/common/src/test/scala/VSFileSpec.scala
+++ b/common/src/test/scala/VSFileSpec.scala
@@ -51,6 +51,7 @@ class VSFileSpec extends Specification{
         "VX-18",
         Some(Map("created"->"1558437337823","mtime"->"1558437337823")),
         None,
+        None,
         None
       )))
     }

--- a/common/src/test/scala/VSGetItemSpec.scala
+++ b/common/src/test/scala/VSGetItemSpec.scala
@@ -1,0 +1,137 @@
+import java.time.ZonedDateTime
+
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
+import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import streamComponents.VSGetItem
+import testhelpers.AkkaTestkitSpecs2Support
+import vidispine.{GetMetadataError, VSCommunicator, VSFile, VSFileItemMembership, VSLazyItem}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.util.Try
+
+class VSGetItemSpec extends Specification with Mockito {
+  "VSGetItem" should {
+    "initialise a VSLazyItem from the given VSFile and populate with the given fields" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fieldList = Seq("field1","field2","field3")
+      implicit val comm:VSCommunicator = mock[VSCommunicator]
+
+      val incomingFile = VSFile("VX-123","/path/to/file","file://path/to/file",None,1234L,None,ZonedDateTime.now(),1,"VX-1",
+        None,Some(VSFileItemMembership("VX-456",Seq())),None,None)
+
+      val mockedItem = mock[VSLazyItem]
+      val lookedUpItem = mock[VSLazyItem]
+      mockedItem.getMoreMetadata(any)(any,any) returns Future(Right(lookedUpItem))
+
+      val mockedMakeItem = mock[String=>VSLazyItem]
+      mockedMakeItem.apply(any) returns mockedItem
+
+      val toTestFact = new VSGetItem(fieldList)(comm,mat,system.dispatcher) {
+        override def makeItem(itemId: String): VSLazyItem = mockedMakeItem(itemId)
+      }
+
+      val sinkFact = Sink.seq[Option[VSLazyItem]]
+
+      val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        //val src = Source.single(incomingFile)
+        val src = builder.add(Source.fromIterator(()=>Seq(incomingFile,incomingFile).toIterator))
+        val vsGetItem = builder.add(toTestFact)
+
+        src ~> vsGetItem
+        vsGetItem.out.map(_._2) ~> sink
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 4 second)
+
+      result.head must beSome(lookedUpItem)
+      there were two(mockedMakeItem).apply("VX-456")
+      there were two(mockedItem).getMoreMetadata(fieldList)
+    }
+
+    "pass through None if the given file is not a member of an item" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fieldList = Seq("field1","field2","field3")
+      implicit val comm:VSCommunicator = mock[VSCommunicator]
+
+      val incomingFile = VSFile("VX-123","/path/to/file","file://path/to/file",None,1234L,None,ZonedDateTime.now(),1,"VX-1",
+        None,None,None,None)
+
+      val mockedItem = mock[VSLazyItem]
+      val lookedUpItem = mock[VSLazyItem]
+      mockedItem.getMoreMetadata(any)(any,any) returns Future(Right(lookedUpItem))
+
+      val mockedMakeItem = mock[String=>VSLazyItem]
+      mockedMakeItem.apply(any) returns mockedItem
+
+      val toTestFact = new VSGetItem(fieldList)(comm,mat,system.dispatcher) {
+        override def makeItem(itemId: String): VSLazyItem = mockedMakeItem(itemId)
+      }
+
+      val sinkFact = Sink.seq[Option[VSLazyItem]]
+
+      val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        //val src = Source.single(incomingFile)
+        val src = builder.add(Source.fromIterator(()=>Seq(incomingFile,incomingFile).toIterator))
+        val vsGetItem = builder.add(toTestFact)
+
+        src ~> vsGetItem
+        vsGetItem.out.map(_._2) ~> sink
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 4 second)
+      result.head must beNone
+      there were no(mockedMakeItem).apply(any)
+      there were no(mockedItem).getMoreMetadata(any)(any,any)
+    }
+
+    "error if lookup fails" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fieldList = Seq("field1","field2","field3")
+      implicit val comm:VSCommunicator = mock[VSCommunicator]
+
+      val incomingFile = VSFile("VX-123","/path/to/file","file://path/to/file",None,1234L,None,ZonedDateTime.now(),1,"VX-1",
+        None,Some(VSFileItemMembership("VX-456",Seq())),None,None)
+
+      val mockedItem = mock[VSLazyItem]
+      val lookedUpItem = mock[VSLazyItem]
+      mockedItem.getMoreMetadata(any)(any,any) returns Future(Left(GetMetadataError(None,None,None)))
+
+      val mockedMakeItem = mock[String=>VSLazyItem]
+      mockedMakeItem.apply(any) returns mockedItem
+
+      val toTestFact = new VSGetItem(fieldList)(comm,mat,system.dispatcher) {
+        override def makeItem(itemId: String): VSLazyItem = mockedMakeItem(itemId)
+      }
+
+      val sinkFact = Sink.seq[Option[VSLazyItem]]
+
+      val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        //val src = Source.single(incomingFile)
+        val src = builder.add(Source.fromIterator(()=>Seq(incomingFile,incomingFile).toIterator))
+        val vsGetItem = builder.add(toTestFact)
+
+        src ~> vsGetItem
+        vsGetItem.out.map(_._2) ~> sink
+        ClosedShape
+      }
+
+      val result = Try { Await.result(RunnableGraph.fromGraph(graph).run(), 4 second) }
+      result must beFailedTry
+    }
+  }
+}

--- a/common/src/test/scala/VSLazyItemSpec.scala
+++ b/common/src/test/scala/VSLazyItemSpec.scala
@@ -28,7 +28,7 @@ class VSLazyItemSpec extends Specification with Mockito {
       val initialItem = VSLazyItem("VX-1234",Map())
 
       implicit val comm:VSCommunicator = mock[VSCommunicator]
-      comm.requestGet(anyString,any,any,any)(any,any) returns Future(Right(returnedXml))
+      comm.request(any,any,any,any,any,any)(any,any) returns Future(Right(returnedXml))
 
       val result = Await.result(initialItem.getMoreMetadata(Seq("field1","field2","field3")), 30 seconds)
 

--- a/common/src/test/scala/VSShapeSpec.scala
+++ b/common/src/test/scala/VSShapeSpec.scala
@@ -819,13 +819,14 @@ class VSShapeSpec extends Specification with Mockito {
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691L,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
             ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None
-          ,None),
+          ,None,None),
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
-            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None, None),
+            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),
+            None, None,None),
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
-            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None)
+            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None,None)
       )
       ))
     }

--- a/common/src/test/scala/VSShapeSpec.scala
+++ b/common/src/test/scala/VSShapeSpec.scala
@@ -818,15 +818,15 @@ class VSShapeSpec extends Specification with Mockito {
         Seq(
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691L,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
-            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None,
-          ),
+            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None
+          ,None),
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
-            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None),
+            ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None, None),
           VSFile("VX-23948","EUBrusselsBrexitDebateRecording.mp4","file:///srv/Proxies2/DevSystem/DAM/Scratch/EUBrusselsBrexitDebateRecording.mp4",
             Some(VSFileState.CLOSED),490896691,Some("af42e9eb15d4643238e990e7714492fc2fa0f8a7"),
             ZonedDateTime.parse("2019-05-21T12:16:34.970+01:00"),1,"VX-18",Some(Map("created" -> "1558437337823", "mtime" -> "1558437337823")),None,None)
-        )
+      )
       ))
     }
   }

--- a/common/src/test/scala/helpers/TrustStoreHelperSpec.scala
+++ b/common/src/test/scala/helpers/TrustStoreHelperSpec.scala
@@ -1,0 +1,98 @@
+package helpers
+
+import java.io.IOException
+import java.security.cert.{CertificateException, X509Certificate}
+
+import javax.net.ssl.X509TrustManager
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+import scala.util.Try
+
+class TrustStoreHelperSpec extends Specification with Mockito {
+  "TrustStoreHelper.getCustomTrustManager" should {
+    "load in certs from a given path" in {
+      if(System.getProperty("HAVE_TEST_KEYSTORE")!=null) {
+        val result = TrustStoreHelper.getCustomTrustManager("keystore.jks", None)
+        result must beSuccessfulTry[X509TrustManager]
+        println(s"Got ${result.get.getAcceptedIssuers.length} issuers")
+        result.get.getAcceptedIssuers.length must beGreaterThan(0)
+      } else {
+        println("TEST SKIPPED - Create a keystore.jks and set system property HAVE_TEST_KEYSTORE to apply it")
+        1 mustEqual 1
+      }
+    }
+
+    "pass on exceptions as a failure" in {
+      val result = TrustStoreHelper.getCustomTrustManager("keystore.jks", Some("FSDfsdfsdfdsfsdfsdffsdf"))
+      result must beFailedTry
+      result.failed.get must beAnInstanceOf[IOException]
+    }
+  }
+
+  "TrustStoreHelper.getDefaultTrustManager" should {
+    "load in the default trust store" in {
+      val result = TrustStoreHelper.getDefaultTrustManager
+      result must beSuccessfulTry[X509TrustManager]
+      println(s"Got ${result.get.getAcceptedIssuers.length} issuers")
+      result.get.getAcceptedIssuers.length must beGreaterThan(10) //we can't reliably test for the _actual_ number of issuers on the system but if it's the default we expect to have a whole bunch there
+    }
+  }
+
+  "TrustStoreHelper.customX509TrustStoreManager's custom manager" should {
+    "delegate checkServerTrusted calls until one succeeds" in {
+      val firstTm = mock[X509TrustManager]
+      firstTm.checkServerTrusted(any,any) throws new CertificateException()
+
+      val secondTm = mock[X509TrustManager]
+      doNothing.when(secondTm).checkServerTrusted(any,any)
+
+      val thirdTm = mock[X509TrustManager]
+      thirdTm.checkServerTrusted(any,any) throws new CertificateException()
+
+      val customTm = TrustStoreHelper.customX509TrustManager(Seq(firstTm,secondTm,thirdTm))
+
+      val result = Try { customTm.checkServerTrusted(Array(),"something") }
+      result must beSuccessfulTry
+      there was one(firstTm).checkServerTrusted(Array(),"something")
+      there was one(secondTm).checkServerTrusted(Array(),"something")
+      there was no(thirdTm).checkServerTrusted(any,any)
+    }
+
+    "throw the last exception if all fail" in {
+      val firstTm = mock[X509TrustManager]
+      firstTm.checkServerTrusted(any,any) throws new CertificateException()
+
+      val secondTm = mock[X509TrustManager]
+      secondTm.checkServerTrusted(any,any) throws new CertificateException()
+
+      val thirdTm = mock[X509TrustManager]
+      thirdTm.checkServerTrusted(any,any) throws new CertificateException()
+
+      val customTm = TrustStoreHelper.customX509TrustManager(Seq(firstTm,secondTm,thirdTm))
+
+      val result = Try { customTm.checkServerTrusted(Array(),"something") }
+      result must beFailedTry
+      result.failed.get must beAnInstanceOf[CertificateException]
+      there was one(firstTm).checkServerTrusted(Array(),"something")
+      there was one(secondTm).checkServerTrusted(Array(),"something")
+      there was one(thirdTm).checkServerTrusted(any,any)
+    }
+
+    "return a list of all the supported issuers" in {
+      val mockedIssuers = Array(mock[X509Certificate],mock[X509Certificate],mock[X509Certificate],mock[X509Certificate],mock[X509Certificate])
+      val firstTm = mock[X509TrustManager]
+      firstTm.getAcceptedIssuers returns Array(mockedIssuers.head,mockedIssuers(1))
+
+      val secondTm = mock[X509TrustManager]
+      secondTm.getAcceptedIssuers returns Array(mockedIssuers(2))
+
+      val thirdTm = mock[X509TrustManager]
+      thirdTm.getAcceptedIssuers returns Array(mockedIssuers(3),mockedIssuers(4))
+
+      val customTm = TrustStoreHelper.customX509TrustManager(Seq(firstTm,secondTm,thirdTm))
+      val result = customTm.getAcceptedIssuers
+      result mustEqual mockedIssuers
+    }
+  }
+}

--- a/frontend/app/RunsInProgress.jsx
+++ b/frontend/app/RunsInProgress.jsx
@@ -57,7 +57,11 @@ class RunsInProgress extends React.Component {
             <ul className="no-bullets">{
                 this.state.runData.map(entry=><li key={entry.jobId}>
                         {/*<ClickableIcon onClick={()=>this.deletionClicked(entry.jobId)} icon="times-circle"/>*/}
-                        {entry.jobType} started <TimestampDiffComponent endTime={entry.scanStart}/><br/>{entry.itemsCounted} items so far
+                        {entry.jobType}:
+                    <ul>
+                        <li><TimestampDiffComponent endTime={entry.scanStart}/></li>
+                        <li>{entry.itemsCounted} items so far</li>
+                    </ul>
                 </li>)
             }</ul>
             <LoadingThrobber show={this.state.loading} small={true}/>

--- a/nearlinescanner/src/main/scala/NearlineScanner.scala
+++ b/nearlinescanner/src/main/scala/NearlineScanner.scala
@@ -10,7 +10,8 @@ import play.api.Logger
 import vidispine.{VSCommunicator, VSFile}
 import com.softwaremill.sttp._
 import helpers.CleanoutFunctions
-import streamComponents.{PeriodicUpdate, PeriodicUpdateBasic, VSStorageScanSource}
+import streamComponents.{PeriodicUpdate, PeriodicUpdateBasic, VSFileIdInList, VSStorageScanSource}
+
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
@@ -21,7 +22,6 @@ object NearlineScanner extends CleanoutFunctions {
 
   private implicit val actorSystem = ActorSystem("NearlineScanner")
   private implicit val mat:Materializer = ActorMaterializer.create(actorSystem)
-
 
   lazy val vsConfig = VSConfig(
     uri"${sys.env("VIDISPINE_BASE_URL")}",
@@ -48,8 +48,8 @@ object NearlineScanner extends CleanoutFunctions {
   lazy implicit val indexer = new VSFileIndexer(indexName, batchSize = 200)
 
   def buildStream(initialJobRecord: JobHistory, storageId:String)(implicit esClient:ElasticClient, jobHistoryDAO: JobHistoryDAO,indexer: VSFileIndexer) = {
-    val counterSink = Sink.fold[Int, VSFile](0)((acc,_)=>acc+1)
-
+    //val counterSink = Sink.fold[Int, VSFile](0)((acc,_)=>acc+1)
+    val counterSink = Sink.seq[String]
     GraphDSL.create(counterSink) { implicit builder=> counter=>
       import akka.stream.scaladsl.GraphDSL.Implicits._
       val src = builder.add(new VSStorageScanSource(Some(storageId), None, vsCommunicator,pageSize=100))
@@ -59,7 +59,29 @@ object NearlineScanner extends CleanoutFunctions {
       val splitter = builder.add(new Broadcast[VSFile](2,eagerCancel = true))
 
       src.out.log("vs-file-indexer-stream") ~> updater ~> splitter ~> sink
-      splitter.out(1) ~> counter
+      splitter.out(1).map(_.vsid) ~> counter
+      ClosedShape
+    }
+  }
+
+  def removeNotFoundStream(initialJobRecord: JobHistory, foundIdsList:Seq[String])(implicit esClient:ElasticClient, jobHistoryDAO: JobHistoryDAO, indexer: VSFileIndexer) = {
+    val counterSink = Sink.fold[Int, VSFile](0)((acc,_)=>acc+1)
+    GraphDSL.create(counterSink) { implicit builder=> counter=>
+      import akka.stream.scaladsl.GraphDSL.Implicits._
+      import com.sksamuel.elastic4s.http.ElasticDsl._
+      import io.circe.generic.auto._
+      import com.sksamuel.elastic4s.circe._
+
+      val src = indexer.getSource(esClient,Seq(matchAllQuery()),limit=None)
+      val listSwitcher = builder.add(new VSFileIdInList(foundIdsList))
+      val ignoreSink = Sink.ignore
+      val deleteSink = indexer.deleteSink(esClient, reallyDelete=true)
+      val counterSplitter = builder.add(Broadcast[VSFile](2))
+
+      src.map(_.to[VSFile]) ~> listSwitcher
+      listSwitcher.out(0) ~> ignoreSink   //"YES" branch - file was in the provided list so it still exists, don't delete it
+      listSwitcher.out(1) ~> counterSplitter ~> deleteSink   //"NO" branch - file was not seen in the previous run so it has been removed from the system; remove it from index
+      counterSplitter.out(1) ~> counter
       ClosedShape
     }
   }
@@ -124,18 +146,25 @@ object NearlineScanner extends CleanoutFunctions {
             complete_run(1,None,None)(null)
             throw new RuntimeException
           case Some(storageId)=>
-            val resultFuture = jobHistoryDAO.put(runInfo).flatMap(_=>{
+            val scanFuture = jobHistoryDAO.put(runInfo).flatMap(_=>{
               logger.info(s"Saved run info ${runInfo.toString}")
               RunnableGraph.fromGraph(buildStream(runInfo,storageId)).run()
+            })
+
+            val resultFuture = scanFuture.flatMap(fileIdsFound=>{
+              logger.info(s"Counted ${fileIdsFound.length} records, purging out non-found records")
+
+              val removalGraph = removeNotFoundStream(runInfo,fileIdsFound)
+              RunnableGraph.fromGraph(removalGraph).run().map(deletedCount=>(deletedCount, fileIdsFound.length))
             })
 
             resultFuture.onComplete({
               case Failure(err)=>
                 logger.error("Could not run stream: ", err)
                 complete_run(1,Some(err.toString),Some(runInfo))
-              case Success(recordCount)=>
-                logger.info(s"Counted $recordCount records, finishing")
-                val updatedRunInfo = runInfo.copy(itemsCounted = recordCount)
+              case Success((deletedCount, foundCount))=>
+                logger.info(s"Purge completed, removed $deletedCount records from the index that are no longer in VS")
+                val updatedRunInfo = runInfo.copy(itemsCounted = foundCount)
                 complete_run(0,None,Some(updatedRunInfo))
             })
         }

--- a/remove-archived-nearline/src/main/scala/Main.scala
+++ b/remove-archived-nearline/src/main/scala/Main.scala
@@ -1,20 +1,25 @@
+import java.time.ZonedDateTime
+
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
-import akka.stream.scaladsl.{Broadcast, GraphDSL}
-import com.amazonaws.services.s3.AmazonS3
-import com.sksamuel.elastic4s.http.ElasticClient
-import config.ESConfig
-import helpers.ZonedDateTimeEncoder
-import models.{ArchiveNearlineEntryIndexer, ArchivedItemRecord, VSFileIndexer}
+import akka.stream.scaladsl.{Broadcast, GraphDSL, RunnableGraph, Sink}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3Builder, AmazonS3ClientBuilder}
+import com.sksamuel.elastic4s.http.{ElasticClient, ElasticProperties}
+import config.{ESConfig, VSConfig}
+import helpers.{CleanoutFunctions, ZonedDateTimeEncoder}
+import models.{ArchiveNearlineEntryIndexer, ArchivedItemRecord, JobHistory, JobHistoryDAO, JobType, VSFileIndexer}
 import org.slf4j.LoggerFactory
 import streamComponents.{DecodeArchiveHunterId, FixVidispineMeta, GetArchivalMetadata, LookupS3Metadata, PostLookupMerge, VSGetItem, VerifyS3Metadata}
 import io.circe.syntax._
+import com.softwaremill.sttp._
 import io.circe.generic.auto._
 import vidispine.{ArchivalMetadata, VSCommunicator, VSFile, VSFileStateEncoder}
-
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success, Try}
 
-object Main extends ZonedDateTimeEncoder with VSFileStateEncoder {
+object Main extends ZonedDateTimeEncoder with VSFileStateEncoder with CleanoutFunctions {
   val logger = LoggerFactory.getLogger(getClass)
 
   private implicit val actorSystem = ActorSystem("CronScanner")
@@ -26,26 +31,39 @@ object Main extends ZonedDateTimeEncoder with VSFileStateEncoder {
     sys.env.getOrElse("ES_PORT","9200").toInt
   )
 
-  lazy val ahBaseUri = sys.env("ARCHIVE_HUNTER_URL")
-  lazy val ahSecret = sys.env("ARCHIVE_HUNTER_SECRET")
-
+  lazy val vsConfig = VSConfig(
+    uri"${sys.env("VIDISPINE_BASE_URL")}",
+    sys.env("VIDISPINE_USER"),
+    sys.env("VIDISPINE_PASSWORD")
+  )
 
   lazy val indexName = sys.env.getOrElse("INDEX_NAME","mediacensus-nearline")
   lazy val archiveIndexName = sys.env.getOrElse("ARCHIVER_INDEX_NAME", "mediacensus-archived-nearline")
   lazy val jobIndexName = sys.env.getOrElse("JOBS_INDEX","mediacensus-jobs")
-  lazy val parallelism = sys.env.getOrElse("PARALELLISM","3").toInt
+  lazy val leaveOpenDays = sys.env.getOrElse("LEAVE_OPEN_DAYS","5").toInt
 
-  lazy implicit val nearlineEntriesIndexer = new VSFileIndexer(indexName, batchSize = 200)
-  lazy implicit val archiveIndexer = new ArchiveNearlineEntryIndexer(archiveIndexName, batchSize = 200)
+  lazy val reallyDeleteItems = sys.env.get("REALLY_DELETE") match {
+    case None=>false
+    case Some("true")=>true
+    case Some("yes")=>true
+    case Some("TRUE")=>true
+    case Some("YES")=>true
+    case _=>false
+  }
+
+  lazy implicit val nearlineEntriesIndexer = new VSFileIndexer(indexName, batchSize = 100)
+  lazy implicit val archiveIndexer = new ArchiveNearlineEntryIndexer(archiveIndexName, batchSize = 100)
 
 
   def createGraph(esClient:ElasticClient,s3Client:AmazonS3,reallyDelete:Boolean)(implicit comm:VSCommunicator) = {
-    GraphDSL.create() { implicit builder=>
+    val counterSinkFact = Sink.fold[Int, VSFile](0)((acc,_)=>acc+1)
+
+    GraphDSL.create(counterSinkFact) { implicit builder=> counterSink=>
       import akka.stream.scaladsl.GraphDSL.Implicits._
       import com.sksamuel.elastic4s.http.ElasticDsl._
       import com.sksamuel.elastic4s.circe._
 
-      val src = builder.add(nearlineEntriesIndexer.getSource(esClient, Seq(existsQuery("archiveHunterId")), limit=None))
+      val src = builder.add(nearlineEntriesIndexer.getSource(esClient, Seq(existsQuery("archiveHunterId")), limit = None))
       val decoder = builder.add(new DecodeArchiveHunterId)
       val metaLookup = builder.add(new LookupS3Metadata(s3Client))
       val metaVerify = builder.add(new VerifyS3Metadata)
@@ -63,9 +81,10 @@ object Main extends ZonedDateTimeEncoder with VSFileStateEncoder {
       val deleteFile = builder.add(new VSDeleteFile(reallyDelete))
       val deleteIndexRecord = nearlineEntriesIndexer.deleteSink(esClient,reallyDelete)
 
+      val deleteSplitter = builder.add(Broadcast[VSFile](2))
       src.out.map(_.to[VSFile]) ~> decoder
-      decoder.out.map(tuple=>ArchivedItemRecord(tuple._1,tuple._2,tuple._3,None)) ~> metaLookup ~> metaVerify
-      metaVerify.out(1).map(_.nearlineItem) ~> writeUpdateSink  // "NO" branch - metadata did not verify against S3, write updated item back to index
+      decoder.out.map(tuple => ArchivedItemRecord(tuple._1, tuple._2, tuple._3, None)) ~> metaLookup ~> metaVerify
+      metaVerify.out(1).map(_.nearlineItem) ~> writeUpdateSink // "NO" branch - metadata did not verify against S3, write updated item back to index
 
       metaVerify.out(0) ~> lookupSplitter
       lookupSplitter.out(0).map(_.nearlineItem) ~> vsLookup
@@ -73,12 +92,85 @@ object Main extends ZonedDateTimeEncoder with VSFileStateEncoder {
       lookupSplitter.out(1) ~> postLookupMerge.in1
 
       postLookupMerge.out ~> fixVidispineMeta
-      fixVidispineMeta.out.map(_.nearlineItem) ~> deleteFile ~> deleteIndexRecord
+      fixVidispineMeta.out.map(_.nearlineItem) ~> deleteFile ~> deleteSplitter
+      deleteSplitter.out(0) ~> deleteIndexRecord
+      deleteSplitter.out(1) ~> counterSink
       ClosedShape
     }
   }
 
-  def main(args:Array[String]) = {
+  def getEsClient = Try {
+    val uri = esConfig.uri match {
+      case Some(uri)=>uri
+      case None=>s"http://${esConfig.host}:${esConfig.port}"
+    }
 
+    ElasticClient(ElasticProperties(uri))
+  }
+
+  def getS3Client = Try {
+    AmazonS3ClientBuilder.standard().build()
+  }
+
+  def complete_run(exitCode:Int, errorMessage:Option[String], runInfo:Option[JobHistory])(implicit jobHistoryDAO: JobHistoryDAO) = {
+    val updateFuture = runInfo match {
+      case Some(jobHistory)=>
+        val updatedJobHistory = jobHistory.copy(scanFinish = Some(ZonedDateTime.now()), lastError = errorMessage)
+        jobHistoryDAO.updateStatusOnly(updatedJobHistory).map({
+          case Left(err)=>logger.error(s"Could not update job history entry: ${err.toString}")
+          case Right(newVersion)=>logger.info(s"Update run ${updatedJobHistory} with new version $newVersion")
+        })
+      case None => Future( () )
+    }
+
+    updateFuture.andThen({
+      case _=>actorSystem.terminate().andThen({
+        case _ => System.exit(exitCode)
+      })
+    })
+  }
+
+
+  def main(args:Array[String]) = {
+    logger.info("Starting up...")
+    val connections = Seq(getEsClient, getS3Client)
+
+    val failures = connections.collect({case Failure(err)=>err})
+    if(failures.nonEmpty){
+      failures.foreach(err=>
+        logger.error(s"Could not establish initial connections: ", err)
+      )
+      System.exit(1)
+    }
+
+    val esClient = connections(0).get.asInstanceOf[ElasticClient]
+    val s3Client = connections(1).get.asInstanceOf[AmazonS3]
+    lazy implicit val vsCommunicator = new VSCommunicator(vsConfig.vsUri, vsConfig.plutoUser, vsConfig.plutoPass)
+
+    logger.info(s"ReallyDelete is set to $reallyDeleteItems")
+
+    lazy implicit val jobHistoryDAO = new JobHistoryDAO(esClient, jobIndexName)
+
+    Await.ready(cleanoutOldJobs(jobHistoryDAO, JobType.CensusScan,leaveOpenDays).map({
+      case Left(errs)=>
+        logger.error(s"Cleanout of old census jobs failed: $errs")
+      case Right(results)=>
+        logger.info(s"Cleanout of old census jobs succeeded: $results")
+    }), 5 minutes)
+
+    val runInfo = JobHistory.newRun(JobType.RemoveArchivedNearline)
+
+    Await.ready(jobHistoryDAO.put(runInfo), 2 minutes)
+
+    val graph = createGraph(esClient, s3Client, reallyDeleteItems)
+
+    RunnableGraph.fromGraph(graph).run().onComplete({
+      case Success(processedItemsCount)=>
+        logger.info(s"Run completed, deleted $processedItemsCount items")
+        Await.ready(complete_run(0,None,Some(runInfo)), 10 minutes)
+      case Failure(err)=>
+        logger.error(s"Run failed: ", err)
+        Await.ready(complete_run(1,Some(err.getMessage),Some(runInfo)), 10 minutes)
+    })
   }
 }

--- a/remove-archived-nearline/src/main/scala/Main.scala
+++ b/remove-archived-nearline/src/main/scala/Main.scala
@@ -1,0 +1,78 @@
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
+import akka.stream.scaladsl.{Broadcast, GraphDSL}
+import com.amazonaws.services.s3.AmazonS3
+import com.sksamuel.elastic4s.http.ElasticClient
+import config.ESConfig
+import models.{ArchiveNearlineEntryIndexer, ArchivedItemRecord, VSFileIndexer}
+import org.slf4j.LoggerFactory
+import streamComponents.{DecodeArchiveHunterId, FixVidispineMeta, GetArchivalMetadata, LookupS3Metadata, PostLookupMerge, VSGetItem, VerifyS3Metadata}
+import io.circe.syntax._
+import io.circe.generic.auto._
+import vidispine.{ArchivalMetadata, VSCommunicator, VSFile}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object Main extends {
+  val logger = LoggerFactory.getLogger(getClass)
+
+  private implicit val actorSystem = ActorSystem("CronScanner")
+  private implicit val mat:Materializer = ActorMaterializer.create(actorSystem)
+
+  lazy val esConfig = ESConfig(
+    sys.env.get("ES_URI"),
+    sys.env.getOrElse("ES_HOST","mediacensus-elasticsearch"),
+    sys.env.getOrElse("ES_PORT","9200").toInt
+  )
+
+  lazy val ahBaseUri = sys.env("ARCHIVE_HUNTER_URL")
+  lazy val ahSecret = sys.env("ARCHIVE_HUNTER_SECRET")
+
+
+  lazy val indexName = sys.env.getOrElse("INDEX_NAME","mediacensus-nearline")
+  lazy val archiveIndexName = sys.env.getOrElse("ARCHIVER_INDEX_NAME", "mediacensus-archived-nearline")
+  lazy val jobIndexName = sys.env.getOrElse("JOBS_INDEX","mediacensus-jobs")
+  lazy val parallelism = sys.env.getOrElse("PARALELLISM","3").toInt
+
+  lazy implicit val nearlineEntriesIndexer = new VSFileIndexer(indexName, batchSize = 200)
+  lazy implicit val archiveIndexer = new ArchiveNearlineEntryIndexer(archiveIndexName, batchSize = 200)
+
+
+  def createGraph(esClient:ElasticClient,s3Client:AmazonS3)(implicit comm:VSCommunicator) = {
+    GraphDSL.create() { implicit builder=>
+      import akka.stream.scaladsl.GraphDSL.Implicits._
+      import com.sksamuel.elastic4s.http.ElasticDsl._
+      import com.sksamuel.elastic4s.circe._
+
+      val src = builder.add(nearlineEntriesIndexer.getSource(esClient, Seq(existsQuery("archiveHunterId")), limit=None))
+      val decoder = builder.add(new DecodeArchiveHunterId)
+      val metaLookup = builder.add(new LookupS3Metadata(s3Client))
+      val metaVerify = builder.add(new VerifyS3Metadata)
+
+      val writeUpdateSink = builder.add(nearlineEntriesIndexer.getSink(esClient))
+
+      val vsLookup = builder.add(new VSGetItem(ArchivalMetadata.interestingFields))
+      val getArchivalMeta = builder.add(new GetArchivalMetadata())
+
+      val lookupSplitter = builder.add(Broadcast[ArchivedItemRecord](2))
+      val postLookupMerge = builder.add(new PostLookupMerge)
+
+      val fixVidispineMeta = builder.add(new FixVidispineMeta())
+
+      src.out.map(_.to[VSFile]) ~> decoder
+      decoder.out.map(tuple=>ArchivedItemRecord(tuple._1,tuple._2,tuple._3,None)) ~> metaLookup ~> metaVerify
+      metaVerify.out(1).map(_.nearlineItem) ~> writeUpdateSink  // "NO" branch - metadata did not verify against S3, write updated item back to index
+
+      metaVerify.out(0) ~> lookupSplitter
+      lookupSplitter.out(0).map(_.nearlineItem) ~> vsLookup
+      vsLookup.out.map(_._2) ~> getArchivalMeta ~> postLookupMerge.in0
+      lookupSplitter.out(1) ~> postLookupMerge.in1
+
+      postLookupMerge.out ~> fixVidispineMeta
+      ClosedShape
+    }
+  }
+  def main(args:Array[String]) = {
+
+  }
+}

--- a/remove-archived-nearline/src/main/scala/Main.scala
+++ b/remove-archived-nearline/src/main/scala/Main.scala
@@ -1,19 +1,20 @@
 import java.time.ZonedDateTime
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.{ConnectionContext, Http, HttpsConnectionContext}
 import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
-import akka.stream.scaladsl.{Broadcast, GraphDSL, RunnableGraph, Sink}
+import akka.stream.scaladsl.{Broadcast, GraphDSL, Merge, RunnableGraph, Sink}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Builder, AmazonS3ClientBuilder}
 import com.sksamuel.elastic4s.http.{ElasticClient, ElasticProperties}
 import config.{ESConfig, VSConfig}
-import helpers.{CleanoutFunctions, ZonedDateTimeEncoder}
+import helpers.{CleanoutFunctions, TrustStoreHelper, ZonedDateTimeEncoder}
 import models.{ArchiveNearlineEntryIndexer, ArchivedItemRecord, JobHistory, JobHistoryDAO, JobType, VSFileIndexer}
 import org.slf4j.LoggerFactory
 import streamComponents.{DecodeArchiveHunterId, FixVidispineMeta, GetArchivalMetadata, LookupS3Metadata, PostLookupMerge, VSGetItem, VerifyS3Metadata}
-import io.circe.syntax._
 import com.softwaremill.sttp._
 import io.circe.generic.auto._
 import vidispine.{ArchivalMetadata, VSCommunicator, VSFile, VSFileStateEncoder}
+
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
@@ -51,9 +52,43 @@ object Main extends ZonedDateTimeEncoder with VSFileStateEncoder with CleanoutFu
     case _=>false
   }
 
+  lazy val extraKeyStores = sys.env.get("EXTRA_KEY_STORES").map(_.split("\\s*,\\s*"))
   lazy implicit val nearlineEntriesIndexer = new VSFileIndexer(indexName, batchSize = 100)
   lazy implicit val archiveIndexer = new ArchiveNearlineEntryIndexer(archiveIndexName, batchSize = 100)
 
+  def testGraph(esClient:ElasticClient,s3Client:AmazonS3,reallyDelete:Boolean)(implicit comm:VSCommunicator) = {
+    val testSink = Sink.seq[ArchivedItemRecord]
+
+    GraphDSL.create(testSink) {implicit builder=> sink=>
+      import akka.stream.scaladsl.GraphDSL.Implicits._
+      import com.sksamuel.elastic4s.http.ElasticDsl._
+      import com.sksamuel.elastic4s.circe._
+
+      val src = builder.add(nearlineEntriesIndexer.getSource(esClient, Seq(existsQuery("archiveHunterId")), limit = None))
+      val decoder = builder.add(new DecodeArchiveHunterId)
+      val metaLookup = builder.add(new LookupS3Metadata(s3Client))
+      val metaVerify = builder.add(new VerifyS3Metadata)
+      val writeUpdateSink = builder.add(nearlineEntriesIndexer.getSink(esClient))
+
+      val lookupSplitter = builder.add(Broadcast[ArchivedItemRecord](2))
+      val postLookupMerge = builder.add(new PostLookupMerge)
+
+      val vsLookup = builder.add(new VSGetItem(ArchivalMetadata.interestingFields))
+      val getArchivalMeta = builder.add(new GetArchivalMetadata())
+
+      src.out.map(_.to[VSFile]) ~> decoder
+      decoder.out.map(tuple => ArchivedItemRecord(tuple._1, tuple._2, tuple._3, None)) ~> metaLookup ~> metaVerify
+      metaVerify.out(0) ~> lookupSplitter
+      metaVerify.out(1).map(_.nearlineItem) ~> writeUpdateSink // "NO" branch - metadata did not verify against S3, write updated item back to index
+
+      lookupSplitter.out(0).map(_.nearlineItem) ~> vsLookup
+      vsLookup.out.map(_._2) ~> getArchivalMeta ~> postLookupMerge.in0
+      lookupSplitter.out(1) ~> postLookupMerge.in1
+
+      postLookupMerge.out ~> sink
+      ClosedShape
+    }
+  }
 
   def createGraph(esClient:ElasticClient,s3Client:AmazonS3,reallyDelete:Boolean)(implicit comm:VSCommunicator) = {
     val counterSinkFact = Sink.fold[Int, VSFile](0)((acc,_)=>acc+1)
@@ -82,6 +117,7 @@ object Main extends ZonedDateTimeEncoder with VSFileStateEncoder with CleanoutFu
       val deleteIndexRecord = nearlineEntriesIndexer.deleteSink(esClient,reallyDelete)
 
       val deleteSplitter = builder.add(Broadcast[VSFile](2))
+
       src.out.map(_.to[VSFile]) ~> decoder
       decoder.out.map(tuple => ArchivedItemRecord(tuple._1, tuple._2, tuple._3, None)) ~> metaLookup ~> metaVerify
       metaVerify.out(1).map(_.nearlineItem) ~> writeUpdateSink // "NO" branch - metadata did not verify against S3, write updated item back to index
@@ -133,6 +169,20 @@ object Main extends ZonedDateTimeEncoder with VSFileStateEncoder with CleanoutFu
 
   def main(args:Array[String]) = {
     logger.info("Starting up...")
+
+    if(extraKeyStores.isDefined){
+      logger.info(s"Loading in extra keystores from ${extraKeyStores.get.mkString(",")}")
+      /* this should set the default SSL context to use the stores as well */
+      TrustStoreHelper.setupTS(extraKeyStores.get) match {
+        case Success(sslContext) =>
+          val https: HttpsConnectionContext = ConnectionContext.https(sslContext)
+          Http().setDefaultClientHttpsContext(https)
+        case Failure(err) =>
+          logger.error(s"Could not set up https certs: ", err)
+          System.exit(1)
+      }
+    }
+
     val connections = Seq(getEsClient, getS3Client)
 
     val failures = connections.collect({case Failure(err)=>err})
@@ -151,7 +201,7 @@ object Main extends ZonedDateTimeEncoder with VSFileStateEncoder with CleanoutFu
 
     lazy implicit val jobHistoryDAO = new JobHistoryDAO(esClient, jobIndexName)
 
-    Await.ready(cleanoutOldJobs(jobHistoryDAO, JobType.CensusScan,leaveOpenDays).map({
+    Await.ready(cleanoutOldJobs(jobHistoryDAO, JobType.RemoveArchivedNearline,leaveOpenDays).map({
       case Left(errs)=>
         logger.error(s"Cleanout of old census jobs failed: $errs")
       case Right(results)=>

--- a/remove-archived-nearline/src/main/scala/models/ArchivedItemRecord.scala
+++ b/remove-archived-nearline/src/main/scala/models/ArchivedItemRecord.scala
@@ -1,6 +1,6 @@
 package models
 
 import com.amazonaws.services.s3.model.ObjectMetadata
-import vidispine.VSFile
+import vidispine.{ArchivalMetadata, VSFile}
 
-case class ArchivedItemRecord (nearlineItem:VSFile, s3Bucket:String, s3Path:String, s3Meta:Option[ObjectMetadata])
+case class ArchivedItemRecord (nearlineItem:VSFile, s3Bucket:String, s3Path:String, s3Meta:Option[ObjectMetadata]=None, vsMeta:Option[ArchivalMetadata]=None)

--- a/remove-archived-nearline/src/main/scala/models/ArchivedItemRecord.scala
+++ b/remove-archived-nearline/src/main/scala/models/ArchivedItemRecord.scala
@@ -1,0 +1,6 @@
+package models
+
+import com.amazonaws.services.s3.model.ObjectMetadata
+import vidispine.VSFile
+
+case class ArchivedItemRecord (nearlineItem:VSFile, s3Bucket:String, s3Path:String, s3Meta:Option[ObjectMetadata])

--- a/remove-archived-nearline/src/main/scala/streamComponents/FixVidispineMeta.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/FixVidispineMeta.scala
@@ -1,0 +1,115 @@
+package streamComponents
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+import akka.stream.{Attributes, FlowShape, Inlet, Materializer, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import models.ArchivedItemRecord
+import org.slf4j.LoggerFactory
+import vidispine.{ArchivalMetadata, VSCommunicator}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+class FixVidispineMeta (implicit vsComm:VSCommunicator, mat:Materializer) extends GraphStage[FlowShape[ArchivedItemRecord,ArchivedItemRecord]] {
+  private val in:Inlet[ArchivedItemRecord] = Inlet.create("FixVidispineMeta.in")
+  private val out:Outlet[ArchivedItemRecord] = Outlet.create("FixVidispineMeta.out")
+
+  override def shape: FlowShape[ArchivedItemRecord, ArchivedItemRecord] = FlowShape.of(in, out)
+
+  /**
+    * check if the metadata needs to be overwritten
+    *
+    * @param meta
+    * @param s3Bucket
+    * @param s3Path
+    * @return a 2-tuple of boolean values. The first indicates whether the metadata needs writing (true=>needs writing). The second indicates whether the
+    *         s3 path is set correctly (true=>yes).
+    */
+  def needsFix(meta:Option[ArchivalMetadata], s3Bucket:String, s3Path:String):(Boolean,Boolean) = {
+    if(meta.isEmpty){
+      (true, true)
+    } else {
+      (meta.get.externalArchiveRequest!=ArchivalMetadata.AR_NONE ||
+      meta.get.externalArchiveStatus!=ArchivalMetadata.AS_ARCHIVED ||
+      !meta.get.externalArchiveDeleteShape,
+        meta.get.externalArchiveDevice==s3Bucket ||
+        meta.get.externalArchivePath==s3Path
+        )
+    }
+  }
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    val successCb = createAsyncCallback[ArchivedItemRecord](rec=>push(out,rec))
+    val failedCb = createAsyncCallback[Throwable](err=>failStage(err))
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        if(elem.nearlineItem.membership.isEmpty){
+          logger.warn(s"No item found for file ${elem.nearlineItem.vsid} ( ${elem.s3Bucket}/${elem.s3Path}), can't update")
+          push(out, elem)
+        } else {
+          val archivalMetaIncoming = elem.vsMeta.get
+
+          val (shouldWrite,correctPath) = needsFix(elem.vsMeta, elem.s3Bucket, elem.s3Path)
+          if(!correctPath){
+            logger.error(s"Vidispine item for file ${elem.nearlineItem.vsid} has archived URL of s3://${archivalMetaIncoming.externalArchiveDevice}/${archivalMetaIncoming.externalArchivePath} but expected s3://${elem.s3Bucket}/${elem.s3Path}")
+            failStage(new RuntimeException("Incorrect archived URL"))
+          }
+
+          val writeFut = if(shouldWrite){
+            val uriPath = s"/API/item/${elem.nearlineItem.membership.get.itemId}/metadata"
+
+            val updatedArchiveReport = archivalMetaIncoming.externalArchiveReport + s"\nFixed by remove-archive-nearline at ${ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)}\n"
+            val updatedMetadataToWrite = ArchivalMetadata(
+              ZonedDateTime.now(),
+              elem.s3Bucket,
+              ArchivalMetadata.AR_NONE,
+              updatedArchiveReport,
+              ArchivalMetadata.AS_ARCHIVED,
+              elem.s3Path,
+              externalArchiveDeleteShape = true,
+              None
+            )
+
+            val updateXmlDoc = updatedMetadataToWrite.makeXml.toString()
+            logger.debug(s"XML content to write: $updateXmlDoc")
+            logger.info(s"Writing updated metadata to $uriPath...")
+            val headersMap = Map[String,String](
+              "Content-Type"->"application/xml",
+              "Content-Length"->updateXmlDoc.length.toString
+            )
+            vsComm.request(VSCommunicator.OperationType.PUT, uriPath, Some(updateXmlDoc),headersMap).map({
+              case Left(err)=>
+                logger.error(s"Vidispine returned an error updating metadata: ${err.toString}")
+                throw new RuntimeException("Vidispine error, consult logs for details")
+              case Right(_)=>
+                logger.info(s"Item updated")
+                Some(updatedMetadataToWrite)
+            })
+          } else {
+            Future(elem.vsMeta)
+          }
+
+          writeFut.onComplete({
+            case Failure(err)=>
+              logger.error(s"Could not update metadata: ", err)
+              failedCb.invoke(err)
+            case Success(metaUpdate)=>
+              successCb.invoke(elem.copy(vsMeta = metaUpdate))
+          })
+        }
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}

--- a/remove-archived-nearline/src/main/scala/streamComponents/FixVidispineMeta.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/FixVidispineMeta.scala
@@ -92,14 +92,14 @@ class FixVidispineMeta (implicit vsComm:VSCommunicator, mat:Materializer) extend
               "Content-Type"->"application/xml",
               "Content-Length"->updateXmlDoc.length.toString
             )
-//            vsComm.request(VSCommunicator.OperationType.PUT, uriPath, Some(updateXmlDoc),headersMap).map({
-//              case Left(err)=>
-//                logger.error(s"Vidispine returned an error updating metadata: ${err.toString}")
-//                throw new RuntimeException("Vidispine error, consult logs for details")
-//              case Right(_)=>
-//                logger.info(s"Item updated")
-//                Some(updatedMetadataToWrite)
-//            })
+            vsComm.request(VSCommunicator.OperationType.PUT, uriPath, Some(updateXmlDoc),headersMap).map({
+              case Left(err)=>
+                logger.error(s"Vidispine returned an error updating metadata: ${err.toString}")
+                throw new RuntimeException("Vidispine error, consult logs for details")
+              case Right(_)=>
+                logger.info(s"Item updated")
+                Some(updatedMetadataToWrite)
+            })
             Future(elem.vsMeta)
           } else {
             logger.info(s"Item ${elem.nearlineItem.membership.get.itemId} did not need metadata update")

--- a/remove-archived-nearline/src/main/scala/streamComponents/GetArchivalMetadata.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/GetArchivalMetadata.scala
@@ -1,0 +1,50 @@
+package streamComponents
+
+import akka.stream.{Attributes, FlowShape, Inlet, Materializer, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import org.slf4j.LoggerFactory
+import vidispine.{ArchivalMetadata, VSCommunicator, VSLazyItem}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+
+/**
+  * looks up archival metadata for the given item
+  */
+class GetArchivalMetadata(implicit vsComm:VSCommunicator, mat:Materializer) extends GraphStage[FlowShape[Option[VSLazyItem], Option[ArchivalMetadata]]] {
+  private val in:Inlet[Option[VSLazyItem]] = Inlet.create("GetArchivalMetadata.in")
+  private val out:Outlet[Option[ArchivalMetadata]] = Outlet.create("GetArchivalMetadata.out")
+
+  override def shape = FlowShape.of(in,out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val item = grab(in)
+
+        if(item.isEmpty){
+          push(out, None)
+        } else {
+          val successCb = createAsyncCallback[ArchivalMetadata](meta => push(out, meta))
+          val failureCb = createAsyncCallback[Throwable](err => failStage(err))
+
+          ArchivalMetadata.fromLazyItem(item.get, alwaysFetch = false).onComplete({
+            case Success(Right(content)) => successCb.invoke(content)
+            case Success(Left(lookupErr)) =>
+              logger.error(s"Could not look up metadata for ${item.get.itemId}: $lookupErr")
+              failureCb.invoke(new RuntimeException("Vidispine lookup failed"))
+            case Failure(err) =>
+              logger.error(s"Failed to look up metadata for ${item.get.itemId}: ", err)
+              failureCb.invoke(err)
+          })
+        }
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}

--- a/remove-archived-nearline/src/main/scala/streamComponents/LookupS3Metadata.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/LookupS3Metadata.scala
@@ -20,11 +20,13 @@ class LookupS3Metadata (client:AmazonS3) extends GraphStage[FlowShape[ArchivedIt
     setHandler(in, new AbstractInHandler {
       override def onPush(): Unit = {
         val elem = grab(in)
+        logger.info(s"Looking up metadata for s3://${elem.s3Bucket}/${elem.s3Path}")
         val maybeMeta = Try { client.getObjectMetadata(elem.s3Bucket, elem.s3Path) }
 
         maybeMeta match {
           case Success(objectMeta)=>
             val result = elem.copy(s3Meta = Some(objectMeta))
+            logger.info(s"Got object metadata for s3://${elem.s3Bucket}/${elem.s3Path}")
             push(out, result)
           case Failure(err)=>
             logger.error(s"Could not look up s3://${elem.s3Bucket}/${elem.s3Path}: ", err)

--- a/remove-archived-nearline/src/main/scala/streamComponents/LookupS3Metadata.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/LookupS3Metadata.scala
@@ -1,0 +1,40 @@
+package streamComponents
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import com.amazonaws.services.s3.AmazonS3
+import models.ArchivedItemRecord
+import org.slf4j.LoggerFactory
+
+import scala.util.{Failure, Success, Try}
+
+class LookupS3Metadata (client:AmazonS3) extends GraphStage[FlowShape[ArchivedItemRecord, ArchivedItemRecord]] {
+  private val in:Inlet[ArchivedItemRecord] = Inlet.create("LookupS3Metadata.in")
+  private val out:Outlet[ArchivedItemRecord] = Outlet.create("LookupS3Metadata.out")
+
+  override def shape: FlowShape[ArchivedItemRecord, ArchivedItemRecord] = FlowShape.of(in,out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        val maybeMeta = Try { client.getObjectMetadata(elem.s3Bucket, elem.s3Path) }
+
+        maybeMeta match {
+          case Success(objectMeta)=>
+            val result = elem.copy(s3Meta = Some(objectMeta))
+            push(out, result)
+          case Failure(err)=>
+            logger.error(s"Could not look up s3://${elem.s3Bucket}/${elem.s3Path}: ", err)
+            failStage(err)
+        }
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}

--- a/remove-archived-nearline/src/main/scala/streamComponents/PostLookupMerge.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/PostLookupMerge.scala
@@ -1,0 +1,62 @@
+package streamComponents
+
+import akka.stream.{Attributes, FanInShape, FanInShape2, Inlet, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import models.ArchivedItemRecord
+import org.slf4j.LoggerFactory
+import vidispine.{ArchivalMetadata, VSFile}
+
+/**
+  * custom merge component that sticks some ArchivalMetadata back into the given ArchivedItemRecord
+  */
+class PostLookupMerge extends GraphStage[FanInShape2[Option[ArchivalMetadata], ArchivedItemRecord, ArchivedItemRecord]] {
+  private val vsMetaIn:Inlet[Option[ArchivalMetadata]] = Inlet.create("PostLookupMerge.vsFileIn")
+  private val itemRecordIn:Inlet[ArchivedItemRecord] = Inlet.create("PostLookupMerge.itemRecordIn")
+  private val out:Outlet[ArchivedItemRecord] = Outlet.create("PostLookupMerge.out")
+
+  override def shape = new FanInShape2(vsMetaIn, itemRecordIn, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    private var vsMeta:Option[ArchivalMetadata] = None
+    private var itemRecord:Option[ArchivedItemRecord] = None
+
+    def makePush() = {
+      push(out, itemRecord.get.copy(vsMeta=vsMeta))
+      vsMeta = None
+      itemRecord = None
+    }
+
+    setHandler(vsMetaIn, new AbstractInHandler {
+      override def onPush(): Unit = {
+        if(vsMeta.isDefined){
+          logger.error("Stream error, tried to set new metadata when there is some there already")
+          failStage(new RuntimeException("Metadata already existed"))
+        } else {
+          vsMeta = grab(vsMetaIn)
+          if(itemRecord.isDefined) makePush()
+        }
+      }
+    })
+
+    setHandler(itemRecordIn, new AbstractInHandler {
+      override def onPush(): Unit = {
+        if(itemRecord.isDefined){
+          logger.error("Stream error, tried to set new item record when there is on there already")
+          failStage(new RuntimeException("Item already existed"))
+        } else {
+          itemRecord = Some(grab(itemRecordIn))
+          if(vsMeta.isDefined) makePush()
+        }
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = {
+        pull(vsMetaIn)
+        pull(itemRecordIn)
+      }
+    })
+  }
+}

--- a/remove-archived-nearline/src/main/scala/streamComponents/VerifyS3Metadata.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/VerifyS3Metadata.scala
@@ -1,0 +1,48 @@
+package streamComponents
+
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import akka.stream.{Attributes, Inlet, Outlet, UniformFanOutShape}
+import models.ArchivedItemRecord
+import org.slf4j.LoggerFactory
+
+class VerifyS3Metadata extends GraphStage[UniformFanOutShape[ArchivedItemRecord,ArchivedItemRecord]] {
+  private final val in:Inlet[ArchivedItemRecord] = Inlet.create("VerifyS3Metadata.in")
+  private final val yes:Outlet[ArchivedItemRecord] = Outlet.create("VerifyS3Metadata.yes")
+  private final val no:Outlet[ArchivedItemRecord] = Outlet.create("VerifyS3Metadata.no")
+
+  override def shape = new UniformFanOutShape[ArchivedItemRecord,ArchivedItemRecord](in,Array(yes,no))
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        elem.s3Meta match {
+          case None=>
+            failStage(new RuntimeException("Can't verify metadata on a record that does not have it"))
+          case Some(meta)=>
+            val sizeMatch = elem.nearlineItem.size==meta.getContentLength
+            val checksumMatch = if(meta.getContentMD5!=null && elem.nearlineItem.hash.isDefined) elem.nearlineItem.hash.get == meta.getContentMD5 else true
+
+            if(! sizeMatch || ! checksumMatch) {
+              logger.warn(s"Could not verify the file ${elem.nearlineItem.uri} at s3://${elem.s3Bucket}/${elem.s3Path}: size match $sizeMatch checksum match $checksumMatch")
+              push(no, elem)
+            } else {
+              logger.info(s"Verified ${elem.nearlineItem.uri} at s3://${elem.s3Bucket}/${elem.s3Path}")
+              push(yes, elem)
+            }
+        }
+
+      }
+    })
+
+    val genericPull = new AbstractOutHandler {
+      override def onPull(): Unit = if(!hasBeenPulled(in)) pull(in)
+    }
+
+    setHandler(yes, genericPull)
+    setHandler(no, genericPull)
+  }
+}

--- a/remove-archived-nearline/src/main/scala/streamComponents/VerifyVSFile.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/VerifyVSFile.scala
@@ -1,0 +1,61 @@
+package streamComponents
+
+import akka.stream.{Attributes, FlowShape, Inlet, Materializer, Outlet, UniformFanOutShape}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import models.ArchivedItemRecord
+import org.slf4j.LoggerFactory
+import vidispine.VSCommunicator
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+
+/**
+  * checks whether the named file actually exists in VS.  Pushes to "yes" if it does and "no" if it doesn't
+  */
+class VerifyVSFile (implicit vsComm:VSCommunicator, mat:Materializer) extends GraphStage[UniformFanOutShape[ArchivedItemRecord, ArchivedItemRecord]] {
+  private final val in:Inlet[ArchivedItemRecord] = Inlet.create("VerifyVSFile.in")
+  private final val yes:Outlet[ArchivedItemRecord] = Outlet.create("VerifyVSFile.yes")
+  private final val no:Outlet[ArchivedItemRecord] = Outlet.create("VerifyVSFile.no")
+
+  override def shape = new UniformFanOutShape[ArchivedItemRecord,ArchivedItemRecord](in,Array(yes,no))
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger:org.slf4j.Logger = LoggerFactory.getLogger(getClass)
+
+    setHandler(in, new AbstractInHandler {
+      val yesCb = createAsyncCallback[ArchivedItemRecord](rec=>push(yes,rec))
+      val noCb = createAsyncCallback[ArchivedItemRecord](rec=>push(no,rec))
+      val failedCb = createAsyncCallback[Throwable](err=>failStage(err))
+
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        val uriPath = s"/API/file/${elem.nearlineItem.vsid}"
+        vsComm.request(VSCommunicator.OperationType.GET,uriPath,None,Map(),Map()).onComplete({
+          case Success(Right(content))=>
+            logger.debug(s"VS file ${elem.nearlineItem.vsid} does exist")
+            yesCb.invoke(elem)
+          case Success(Left(httpError))=>
+            httpError.errorCode match {
+              case 404=>
+                logger.debug(s"VS file ${elem.nearlineItem.vsid} does not exist")
+                noCb.invoke(elem)
+              case _=>
+                logger.error(s"Unexpected response from Vidispine: ${httpError.errorCode} ${httpError.message}")
+                failedCb.invoke(new RuntimeException("Unexpected response from Vidispine"))
+            }
+          case Failure(err)=>
+            logger.error(s"VS lookup crashed: ", err)
+            failedCb.invoke(err)
+        })
+      }
+    })
+
+    val genericHandler = new AbstractOutHandler {
+      override def onPull(): Unit = if(!hasBeenPulled(in)) pull(in)
+    }
+
+    setHandler(yes, genericHandler)
+    setHandler(no, genericHandler)
+  }
+}

--- a/remove-archived-nearline/src/main/scala/streamComponents/VerifyVSMetadata.scala
+++ b/remove-archived-nearline/src/main/scala/streamComponents/VerifyVSMetadata.scala
@@ -1,0 +1,5 @@
+package streamComponents
+
+class VerifyVSMetadata {
+
+}

--- a/remove-archived-nearline/src/test/scala/streamComponents/VerifyS3MetadataSpec.scala
+++ b/remove-archived-nearline/src/test/scala/streamComponents/VerifyS3MetadataSpec.scala
@@ -24,7 +24,7 @@ class VerifyS3MetadataSpec extends Specification with Mockito{
 
       val sampleRecord = ArchivedItemRecord(
         VSFile(
-          "VX-1234","/some/path","file://some/path",None,1234L,Some("fake-hash"),ZonedDateTime.now(),1,"VX-21",None,None,None
+          "VX-1234","/some/path","file://some/path",None,1234L,Some("fake-hash"),ZonedDateTime.now(),1,"VX-21",None,None,None,None
         ),
         "some-bucket",
         "some/path",
@@ -47,7 +47,166 @@ class VerifyS3MetadataSpec extends Specification with Mockito{
 
       val result = Await.result(RunnableGraph.fromGraph(graph).run(), 30 seconds)
 
-      result.head mustEqual sampleRecord
+      result.head.s3Bucket mustEqual sampleRecord.s3Bucket
+      result.head.s3Path mustEqual sampleRecord.s3Path
+      result.head.s3Meta mustEqual sampleRecord.s3Meta
+      result.head.nearlineItem mustEqual sampleRecord.nearlineItem.copy(archiveConflict = Some(false))
+      result.length mustEqual 1
+    }
+
+    "push to YES if the size matches and there is no hash with the fields in the ObjectMetadata" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fakeObjectMetadata = mock[ObjectMetadata]
+      fakeObjectMetadata.getContentLength returns 1234L
+      fakeObjectMetadata.getContentMD5 returns null
+
+      val sampleRecord = ArchivedItemRecord(
+        VSFile(
+          "VX-1234","/some/path","file://some/path",None,1234L,Some("fake-hash"),ZonedDateTime.now(),1,"VX-21",None,None,None,None
+        ),
+        "some-bucket",
+        "some/path",
+        Some(fakeObjectMetadata)
+      )
+
+      val sinkFactory = Sink.seq[ArchivedItemRecord]
+      val graph = GraphDSL.create(sinkFactory) {implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(Source.single(sampleRecord))
+        val toTest = builder.add(new VerifyS3Metadata)
+        val ignore = builder.add(Sink.ignore)
+
+        src ~> toTest
+        toTest.out(0) ~> sink
+        toTest.out(1) ~> ignore
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 30 seconds)
+
+      result.head.s3Bucket mustEqual sampleRecord.s3Bucket
+      result.head.s3Path mustEqual sampleRecord.s3Path
+      result.head.s3Meta mustEqual sampleRecord.s3Meta
+      result.head.nearlineItem mustEqual sampleRecord.nearlineItem.copy(archiveConflict = Some(false))
+      result.length mustEqual 1
+    }
+
+    "push to YES if the size matches and there is no hash with the fields in the ObjectMetadata" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fakeObjectMetadata = mock[ObjectMetadata]
+      fakeObjectMetadata.getContentLength returns 1234L
+      fakeObjectMetadata.getContentMD5 returns "some-hash"
+
+      val sampleRecord = ArchivedItemRecord(
+        VSFile(
+          "VX-1234","/some/path","file://some/path",None,1234L,None,ZonedDateTime.now(),1,"VX-21",None,None,None,None
+        ),
+        "some-bucket",
+        "some/path",
+        Some(fakeObjectMetadata)
+      )
+
+      val sinkFactory = Sink.seq[ArchivedItemRecord]
+      val graph = GraphDSL.create(sinkFactory) {implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(Source.single(sampleRecord))
+        val toTest = builder.add(new VerifyS3Metadata)
+        val ignore = builder.add(Sink.ignore)
+
+        src ~> toTest
+        toTest.out(0) ~> sink
+        toTest.out(1) ~> ignore
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 30 seconds)
+
+      result.head.s3Bucket mustEqual sampleRecord.s3Bucket
+      result.head.s3Path mustEqual sampleRecord.s3Path
+      result.head.s3Meta mustEqual sampleRecord.s3Meta
+      result.head.nearlineItem mustEqual sampleRecord.nearlineItem.copy(archiveConflict = Some(false))
+      result.length mustEqual 1
+    }
+
+    "push to NO if the has does not match the ObjectMetadata" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fakeObjectMetadata = mock[ObjectMetadata]
+      fakeObjectMetadata.getContentLength returns 1234L
+      fakeObjectMetadata.getContentMD5 returns "fake-hash-different"
+
+      val sampleRecord = ArchivedItemRecord(
+        VSFile(
+          "VX-1234","/some/path","file://some/path",None,1234L,Some("fake-hash"),ZonedDateTime.now(),1,"VX-21",None,None,None,None
+        ),
+        "some-bucket",
+        "some/path",
+        Some(fakeObjectMetadata)
+      )
+
+      val sinkFactory = Sink.seq[ArchivedItemRecord]
+      val graph = GraphDSL.create(sinkFactory) {implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(Source.single(sampleRecord))
+        val toTest = builder.add(new VerifyS3Metadata)
+        val ignore = builder.add(Sink.ignore)
+
+        src ~> toTest
+        toTest.out(0) ~> ignore
+        toTest.out(1) ~> sink
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 30 seconds)
+
+      result.head.s3Bucket mustEqual sampleRecord.s3Bucket
+      result.head.s3Path mustEqual sampleRecord.s3Path
+      result.head.s3Meta mustEqual sampleRecord.s3Meta
+      result.head.nearlineItem mustEqual sampleRecord.nearlineItem.copy(archiveConflict = Some(true))
+      result.length mustEqual 1
+    }
+
+    "push to NO if the size does not match the ObjectMetadata" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fakeObjectMetadata = mock[ObjectMetadata]
+      fakeObjectMetadata.getContentLength returns 12345L
+      fakeObjectMetadata.getContentMD5 returns "fake-hash"
+
+      val sampleRecord = ArchivedItemRecord(
+        VSFile(
+          "VX-1234","/some/path","file://some/path",None,1234L,Some("fake-hash"),ZonedDateTime.now(),1,"VX-21",None,None,None,None
+        ),
+        "some-bucket",
+        "some/path",
+        Some(fakeObjectMetadata)
+      )
+
+      val sinkFactory = Sink.seq[ArchivedItemRecord]
+      val graph = GraphDSL.create(sinkFactory) {implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(Source.single(sampleRecord))
+        val toTest = builder.add(new VerifyS3Metadata)
+        val ignore = builder.add(Sink.ignore)
+
+        src ~> toTest
+        toTest.out(0) ~> ignore
+        toTest.out(1) ~> sink
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 30 seconds)
+
+      result.head.s3Bucket mustEqual sampleRecord.s3Bucket
+      result.head.s3Path mustEqual sampleRecord.s3Path
+      result.head.s3Meta mustEqual sampleRecord.s3Meta
+      result.head.nearlineItem mustEqual sampleRecord.nearlineItem.copy(archiveConflict = Some(true))
       result.length mustEqual 1
     }
   }

--- a/remove-archived-nearline/src/test/scala/streamComponents/VerifyS3MetadataSpec.scala
+++ b/remove-archived-nearline/src/test/scala/streamComponents/VerifyS3MetadataSpec.scala
@@ -1,0 +1,54 @@
+package streamComponents
+import java.time.ZonedDateTime
+
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
+import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
+import com.amazonaws.services.s3.model.ObjectMetadata
+import models.ArchivedItemRecord
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import testhelpers.AkkaTestkitSpecs2Support
+import vidispine.VSFile
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class VerifyS3MetadataSpec extends Specification with Mockito{
+  "VerifyS3Metadata" should {
+    "push to YES if the fields in the VSFile match with the fields in the ObjectMetadata" in new AkkaTestkitSpecs2Support {
+      implicit val mat:Materializer = ActorMaterializer.create(system)
+
+      val fakeObjectMetadata = mock[ObjectMetadata]
+      fakeObjectMetadata.getContentLength returns 1234L
+      fakeObjectMetadata.getContentMD5 returns "fake-hash"
+
+      val sampleRecord = ArchivedItemRecord(
+        VSFile(
+          "VX-1234","/some/path","file://some/path",None,1234L,Some("fake-hash"),ZonedDateTime.now(),1,"VX-21",None,None,None
+        ),
+        "some-bucket",
+        "some/path",
+        Some(fakeObjectMetadata)
+      )
+
+      val sinkFactory = Sink.seq[ArchivedItemRecord]
+      val graph = GraphDSL.create(sinkFactory) {implicit builder=> sink=>
+        import akka.stream.scaladsl.GraphDSL.Implicits._
+
+        val src = builder.add(Source.single(sampleRecord))
+        val toTest = builder.add(new VerifyS3Metadata)
+        val ignore = builder.add(Sink.ignore)
+
+        src ~> toTest
+        toTest.out(0) ~> sink
+        toTest.out(1) ~> ignore
+        ClosedShape
+      }
+
+      val result = Await.result(RunnableGraph.fromGraph(graph).run(), 30 seconds)
+
+      result.head mustEqual sampleRecord
+      result.length mustEqual 1
+    }
+  }
+}

--- a/remove-archived-nearline/src/test/scala/testhelpers/AkkaTestkitSpecs2Support.scala
+++ b/remove-archived-nearline/src/test/scala/testhelpers/AkkaTestkitSpecs2Support.scala
@@ -1,0 +1,16 @@
+package testhelpers
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import org.specs2.mutable.After
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/* A tiny class that can be used as a Specs2 ‘context’. */
+abstract class AkkaTestkitSpecs2Support extends TestKit(ActorSystem())
+  with After
+  with ImplicitSender {
+  // make sure we shut down the actor system after all tests have run
+  def after = Await.result(system.terminate(), 30 seconds)
+}

--- a/vs-fix-missing-files/src/test/scala/VSFileHasItemSpec.scala
+++ b/vs-fix-missing-files/src/test/scala/VSFileHasItemSpec.scala
@@ -17,7 +17,7 @@ class VSFileHasItemSpec extends Specification with Mockito {
       implicit val mat:Materializer = ActorMaterializer.create(system)
 
       val testFile = VSFile("VX-1234","/path/to/file","proto://some-uri",Some(VSFileState.CLOSED),1234L,
-        None,ZonedDateTime.now(),0,"VX-2",None,Some(VSFileItemMembership("VX-345",Seq())),None)
+        None,ZonedDateTime.now(),0,"VX-2",None,Some(VSFileItemMembership("VX-345",Seq())),None,None)
 
       val sinkFactory = Sink.fold[Seq[String],String](Seq())((acc, entry)=>acc++Seq(entry))
 
@@ -44,7 +44,7 @@ class VSFileHasItemSpec extends Specification with Mockito {
       implicit val mat:Materializer = ActorMaterializer.create(system)
 
       val testFile = VSFile("VX-1234","/path/to/file","proto://some-uri",Some(VSFileState.CLOSED),1234L,
-        None,ZonedDateTime.now(),0,"VX-2",None,None,None)
+        None,ZonedDateTime.now(),0,"VX-2",None,None,None,None)
 
       val sinkFactory = Sink.fold[Seq[String],String](Seq())((acc, entry)=>acc++Seq(entry))
 


### PR DESCRIPTION
Updates the nearline scanners to automatically remove from the index items that are no longer present on the nearline.
Adds a new timed action that will delete _from Vidispine_ files that are present on nearline and in the archive.