### PR TITLE
Output list of files in a given "clogging" status

### DIFF
--- a/app/controllers/NearlineDataController.scala
+++ b/app/controllers/NearlineDataController.scala
@@ -2,9 +2,11 @@ package controllers
 
 import java.time.ZonedDateTime
 
+import akka.actor.ActorSystem
+import akka.util.ByteString
 import helpers.{ESClientManager, ZonedDateTimeEncoder}
 import javax.inject.Inject
-import models.{MembershipAggregationData, VSFileIndexer}
+import models.{ArchiveNearlineEntry, MediaStatusValue, MembershipAggregationData, UnclogOutputIndexer, VSFileIndexer}
 import org.slf4j.LoggerFactory
 import play.api.Configuration
 import play.api.libs.circe.Circe
@@ -17,13 +19,17 @@ import vidispine.VSFileStateEncoder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class NearlineDataController @Inject() (config:Configuration, cc:ControllerComponents, esClientMgr:ESClientManager) extends AbstractController(cc) with Circe with ZonedDateTimeEncoder with VSFileStateEncoder {
+class NearlineDataController @Inject() (config:Configuration, cc:ControllerComponents, esClientMgr:ESClientManager)(implicit sys:ActorSystem)
+  extends AbstractController(cc) with Circe with ZonedDateTimeEncoder with VSFileStateEncoder {
   private val logger = LoggerFactory.getLogger(getClass)
 
   private val esClient = esClientMgr.getCachedClient()
   private val indexName = config.get[String]("elasticsearch.nearlineIndexName")
 
   private val indexer = new VSFileIndexer(indexName)
+
+  private val unclogIndexName = config.get[String]("elasticsearch.unclogIndexName")
+  private val unclogIndexer = new UnclogOutputIndexer(unclogIndexName)
 
   def currentStateData = Action.async {
     indexer.aggregateByStateAndStorage(esClient).map({
@@ -71,5 +77,15 @@ class NearlineDataController @Inject() (config:Configuration, cc:ControllerCompo
       case Right(stats)=>
         Ok(stats.asJson)
     })
+  }
+
+  def byCloggingStatus(status:Option[String]) = Action {
+    if(status.isEmpty) {
+      BadRequest(GenericResponse("missing_args","you must specify the 'status' argument").asJson)
+    } else {
+      val realStatus = MediaStatusValue.withName(status.get)
+      val src = unclogIndexer.NearlineEntriesForStatus(realStatus, esClient, indexer)
+      Ok.chunked(src.map(vsFile=>ByteString(vsFile.asJson.noSpaces)))
+    }
   }
 }

--- a/common/src/main/scala/models/VSFileIndexer.scala
+++ b/common/src/main/scala/models/VSFileIndexer.scala
@@ -201,6 +201,18 @@ class VSFileIndexer(val indexName:String, batchSize:Int=20, concurrentBatches:In
     })
   }
 
+  def getById(esClient:ElasticClient, vsid:String) = {
+    esClient.execute {
+      get(indexName, "vsfile", vsid)
+    }.map(response=>{
+      if(response.isError){
+        Left(response.error)
+      } else {
+        Right(response.result.to[VSFile])
+      }
+    })
+  }
+
   /**
     * obtains statistics for how many items have the "ArchiveHunterId" field set, i.e. are also present in deep archive
     * returns either an error string or Map containing "total_count" and "missing_archive_id_count" fields boths as Long

--- a/common/src/main/scala/models/VSFileIndexer.scala
+++ b/common/src/main/scala/models/VSFileIndexer.scala
@@ -208,7 +208,18 @@ class VSFileIndexer(val indexName:String, batchSize:Int=20, concurrentBatches:In
       if(response.isError){
         Left(response.error)
       } else {
-        Right(response.result.to[VSFile])
+        if(response.status==404){
+          Right(VSFile(vsid,"","",None,-1L,None,ZonedDateTime.now(),0,"none",None,None,None,None))
+        } else {
+          response.result.safeTo[VSFile] match {
+            case Success(vsFile) =>
+              Right(vsFile)
+            case Failure(err) =>
+              logger.error(s"Offending data was ${response.result.sourceAsString}")
+              logger.error("Could not decode result from VSFile: ", err)
+              throw err
+          }
+        }
       }
     })
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -322,5 +322,7 @@ elasticsearch {
   jobsHistoryIndex = ${?JOBS_INDEX_NAME}
   nearlineIndexName = "mediacensus-nearline"
   nearlineIndexName = ${?NEARLINE_INDEX_NAME}
+    unclogIndexName = "unclog-nearline"
+    unclogIndexName = ${?UNCLOG_INDEX_NAME}
 }
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -33,7 +33,10 @@
   <logger name="responses.HistogramDataResponse$" level="INFO"/>
   <logger name="controllers.StatsController" level="WARN"/>
 
+  <logger name="nearline-entries-for-status-stream" level="DEBUG"/>
   <logger name="archivehunter.ArchiveHunterRequestor" level="DEBUG"/>
+  <logger name="akka.actor.RepointableActorRef" level="DEBUG"/>
+
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
   <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
   <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />

--- a/conf/routes
+++ b/conf/routes
@@ -14,6 +14,7 @@ GET     /api/nearline/currentState  @controllers.NearlineDataController.currentS
 GET     /api/nearline/membership    @controllers.NearlineDataController.membershipStatsData
 GET     /api/nearline/files         @controllers.NearlineDataController.fileSearch(start:Option[String],duration:Option[Int],limit:Option[Int],orphanOnly:Boolean?=false)
 GET     /api/nearline/archivedStats @controllers.NearlineDataController.archivedStatsData
+GET     /api/nearline/byCloggingStatus @controllers.NearlineDataController.byCloggingStatus(status:Option[String])
 
 GET     /api/jobs/:jobType/forTimespan  @controllers.JobsController.jobsForTimespan(jobType, startAt:Option[String]?=None,endAt:Option[String]?=None,showRunning:Boolean?=false)
 GET     /api/jobs/running               @controllers.JobsController.runningJobs(limit:Option[Int])


### PR DESCRIPTION
Adds an endpoint that will stream out VSFile records of every item that is known to be in a state that "clogs up" the nearline, so they can be extracted out