### PR TITLE
Unclog Nearline User Interface

### DIFF
--- a/app/controllers/UnclogNearlineDataController.scala
+++ b/app/controllers/UnclogNearlineDataController.scala
@@ -6,14 +6,18 @@ import javax.inject.Inject
 import org.slf4j.LoggerFactory
 import play.api.Configuration
 import play.api.mvc.{AbstractController, ControllerComponents}
-import models.UnclogOutputIndexer
-import responses.GenericResponse
+import models.{MediaStatusValue, UnclogOutputIndexer}
+import responses.{GenericResponse, ObjectGetResponse, ObjectListResponse}
 import io.circe.generic.auto._
 import io.circe.syntax._
 import play.api.libs.circe.Circe
+
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 class UnclogNearlineDataController @Inject() (config:Configuration, esClientMgr:ESClientManager, cc:ControllerComponents) extends AbstractController(cc) with Circe {
+  import models.MediaStatusValueEncoder._
   private val logger = LoggerFactory.getLogger(getClass)
   lazy val indexName = config.get[String]("elasticsearch.unclogIndexName")
 
@@ -28,5 +32,39 @@ class UnclogNearlineDataController @Inject() (config:Configuration, esClientMgr:
       case Right(dataMap)=>
         Ok(dataMap.asJson)
     })
+  }
+
+  def recordsForMediaStatus(statusValueString:String, startAt:Option[Int], limit:Option[Int]) = Action.async {
+    val realLimit = limit.getOrElse(100)
+    val realStartAt = startAt.getOrElse(0)
+    Try { MediaStatusValue.withName(statusValueString) } match {
+      case Failure(err)=>
+        logger.error(err.toString)
+        Future(BadRequest(GenericResponse("bad_request","invalid status value").asJson))
+      case Success(statusValue)=>
+        indexer.recordsForMediaStatus(statusValue, realStartAt, realLimit).map({
+          case Left(err)=>
+            logger.error(s"Could not list out items for state ${statusValue}: ", err)
+            InternalServerError(GenericResponse("db_error", err.toString).asJson)
+          case Right((results, hitCount))=>
+            Ok(ObjectListResponse("ok","unclog-nearline", results, hitCount.toInt).asJson)
+        })
+    }
+  }
+
+  def projectsForMediaStatus(statusValueString:String) = Action.async {
+    Try { MediaStatusValue.withName(statusValueString) } match {
+      case Failure(err)=>
+        logger.error(err.toString)
+        Future(BadRequest(GenericResponse("bad_request","invalid status value").asJson))
+      case Success(statusValue)=>
+        indexer.projectsForMediaStatus(statusValue).map({
+          case Left(err)=>
+            logger.error(s"Could not list out items for state ${statusValue}: ", err)
+            InternalServerError(GenericResponse("db_error", err.toString).asJson)
+          case Right(results)=>
+            Ok(ObjectGetResponse("ok","projects-breakdown",results).asJson)
+        })
+    }
   }
 }

--- a/app/controllers/UnclogNearlineDataController.scala
+++ b/app/controllers/UnclogNearlineDataController.scala
@@ -1,0 +1,32 @@
+package controllers
+
+import com.sksamuel.elastic4s.http.ElasticClient
+import helpers.ESClientManager
+import javax.inject.Inject
+import org.slf4j.LoggerFactory
+import play.api.Configuration
+import play.api.mvc.{AbstractController, ControllerComponents}
+import models.UnclogOutputIndexer
+import responses.GenericResponse
+import io.circe.generic.auto._
+import io.circe.syntax._
+import play.api.libs.circe.Circe
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class UnclogNearlineDataController @Inject() (config:Configuration, esClientMgr:ESClientManager, cc:ControllerComponents) extends AbstractController(cc) with Circe {
+  private val logger = LoggerFactory.getLogger(getClass)
+  lazy val indexName = config.get[String]("elasticsearch.unclogIndexName")
+
+  private lazy val indexer = new UnclogOutputIndexer(indexName)
+
+  private implicit val esClient:ElasticClient = esClientMgr.getCachedClient()
+
+  def mediaStatusStats = Action.async {
+    indexer.getMediaStatusStats.map({
+      case Left(err)=>
+        InternalServerError(GenericResponse("db_error", err.toString).asJson)
+      case Right(dataMap)=>
+        Ok(dataMap.asJson)
+    })
+  }
+}

--- a/common/src/main/scala/models/GenericAggregationValue.scala
+++ b/common/src/main/scala/models/GenericAggregationValue.scala
@@ -1,0 +1,3 @@
+package models
+
+case class GenericAggregationValue(label:String,count:Int, size:Long)

--- a/common/src/main/scala/models/ProjectsAggregationValue.scala
+++ b/common/src/main/scala/models/ProjectsAggregationValue.scala
@@ -1,0 +1,3 @@
+package models
+
+case class ProjectsAggregationValue(label:String,count:Int, projects:Int, size:Long)

--- a/common/src/main/scala/models/UnclogOutputIndexer.scala
+++ b/common/src/main/scala/models/UnclogOutputIndexer.scala
@@ -68,7 +68,7 @@ class UnclogOutputIndexer(indexName:String, batchSize:Int=20, concurrentBatches:
   }
 
   def getMediaStatusStats(implicit client:ElasticClient) = client.execute {
-    search(indexName) aggs termsAgg("mediastatus","MediaStatus.keyword").subaggs(sumAgg("size","FileSize"))
+    search(indexName) size 0 aggs termsAgg("mediastatus","MediaStatus.keyword").subaggs(sumAgg("size","FileSize"))
   }.map(response=>{
     if(response.isError) {
       Left(response.error)
@@ -78,9 +78,37 @@ class UnclogOutputIndexer(indexName:String, batchSize:Int=20, concurrentBatches:
       val buckets = aggregateData("buckets").asInstanceOf[List[Map[String,Any]]]
 
       val output = buckets.map(entry=>{
-//        val resultData = kv._2.asInstanceOf[Map[String,Any]]
-//
-//        kv._1 -> GenericAggregationValue(resultData("doc_count").asInstanceOf[Int],resultData("size").asInstanceOf[Long])
+        GenericAggregationValue(
+          entry("key").asInstanceOf[String],
+          entry("doc_count").asInstanceOf[Int],
+          entry("size").asInstanceOf[Map[String,Double]]("value").toLong
+        )
+      })
+      Right(output)
+    }
+  })
+
+  def recordsForMediaStatus(statusValue: MediaStatusValue.Value, startAt:Int, limit:Int)(implicit client:ElasticClient) = client.execute( {
+    search(indexName) query termQuery("MediaStatus.keyword", statusValue.toString) size limit from startAt aggs termsAgg("parent_project", "ParentCollectionIds.keyword")
+  }).map(response=>{
+    if(response.isError) {
+      Left(response.error)
+    } else {
+      Right((response.result.to[UnclogOutput],response.result.totalHits))
+    }
+  })
+
+  def projectsForMediaStatus(statusValue: MediaStatusValue.Value)(implicit client:ElasticClient) = client.execute( {
+    search(indexName) query termQuery("MediaStatus.keyword", statusValue.toString) size 0 aggs termsAgg("parent_project", "ParentCollectionIds.keyword").subaggs(sumAgg("size","FileSize"))
+  }).map(response=>{
+    if(response.isError) {
+      Left(response.error)
+    } else {
+      val aggregateData = response.result.aggregationsAsMap("parent_project").asInstanceOf[Map[String,Any]]
+      logger.debug(s"got aggregate data: $aggregateData")
+      val buckets = aggregateData("buckets").asInstanceOf[List[Map[String,Any]]]
+
+      val output = buckets.map(entry=>{
         GenericAggregationValue(
           entry("key").asInstanceOf[String],
           entry("doc_count").asInstanceOf[Int],

--- a/common/src/main/scala/models/UnclogOutputIndexer.scala
+++ b/common/src/main/scala/models/UnclogOutputIndexer.scala
@@ -68,19 +68,23 @@ class UnclogOutputIndexer(indexName:String, batchSize:Int=20, concurrentBatches:
   }
 
   def getMediaStatusStats(implicit client:ElasticClient) = client.execute {
-    search(indexName) size 0 aggs termsAgg("mediastatus","MediaStatus.keyword").subaggs(sumAgg("size","FileSize"))
+    search(indexName) size 0 aggs termsAgg("mediastatus","MediaStatus.keyword").subaggs(sumAgg("size","FileSize"),
+      cardinalityAgg("projectCount", "ParentCollectionIds.keyword"))
   }.map(response=>{
     if(response.isError) {
       Left(response.error)
     } else {
+      val testData = response.result.aggregationsAsMap("mediastatus")
+      logger.debug(s"got test data: $testData")
       val aggregateData = response.result.aggregationsAsMap("mediastatus").asInstanceOf[Map[String,Any]]
       logger.debug(s"got aggregate data: $aggregateData")
       val buckets = aggregateData("buckets").asInstanceOf[List[Map[String,Any]]]
 
       val output = buckets.map(entry=>{
-        GenericAggregationValue(
+        ProjectsAggregationValue(
           entry("key").asInstanceOf[String],
           entry("doc_count").asInstanceOf[Int],
+          entry("projectCount").asInstanceOf[Map[String,Int]]("value"),
           entry("size").asInstanceOf[Map[String,Double]]("value").toLong
         )
       })

--- a/common/src/main/scala/models/UnclogOutputIndexer.scala
+++ b/common/src/main/scala/models/UnclogOutputIndexer.scala
@@ -99,7 +99,7 @@ class UnclogOutputIndexer(indexName:String, batchSize:Int=20, concurrentBatches:
   })
 
   def projectsForMediaStatus(statusValue: MediaStatusValue.Value)(implicit client:ElasticClient) = client.execute( {
-    search(indexName) query termQuery("MediaStatus.keyword", statusValue.toString) size 0 aggs termsAgg("parent_project", "ParentCollectionIds.keyword").size(128).subaggs(sumAgg("size","FileSize"))
+    search(indexName) query termQuery("MediaStatus.keyword", statusValue.toString) size 0 aggs termsAgg("parent_project", "ParentCollectionIds.keyword").size(129).subaggs(sumAgg("size","FileSize"))
   }).map(response=>{
     if(response.isError) {
       Left(response.error)

--- a/common/src/main/scala/models/UnclogOutputIndexer.scala
+++ b/common/src/main/scala/models/UnclogOutputIndexer.scala
@@ -99,7 +99,7 @@ class UnclogOutputIndexer(indexName:String, batchSize:Int=20, concurrentBatches:
   })
 
   def projectsForMediaStatus(statusValue: MediaStatusValue.Value)(implicit client:ElasticClient) = client.execute( {
-    search(indexName) query termQuery("MediaStatus.keyword", statusValue.toString) size 0 aggs termsAgg("parent_project", "ParentCollectionIds.keyword").subaggs(sumAgg("size","FileSize"))
+    search(indexName) query termQuery("MediaStatus.keyword", statusValue.toString) size 0 aggs termsAgg("parent_project", "ParentCollectionIds.keyword").size(128).subaggs(sumAgg("size","FileSize"))
   }).map(response=>{
     if(response.isError) {
       Left(response.error)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -322,7 +322,7 @@ elasticsearch {
   jobsHistoryIndex = ${?JOBS_INDEX_NAME}
   nearlineIndexName = "mediacensus-nearline"
   nearlineIndexName = ${?NEARLINE_INDEX_NAME}
-    unclogIndexName = "unclog-nearline"
-    unclogIndexName = ${?UNCLOG_INDEX_NAME}
+  unclogIndexName = "unclog-nearline"
+  unclogIndexName = ${?UNCLOG_INDEX_NAME}
 }
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -34,6 +34,8 @@
   <logger name="controllers.StatsController" level="WARN"/>
 
   <logger name="nearline-entries-for-status-stream" level="DEBUG"/>
+  <logger name="models.UnclogOutputIndexer" level="DEBUG"/>
+
   <logger name="archivehunter.ArchiveHunterRequestor" level="DEBUG"/>
   <logger name="akka.actor.RepointableActorRef" level="DEBUG"/>
 

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,8 @@ GET     /api/nearline/files         @controllers.NearlineDataController.fileSear
 GET     /api/nearline/archivedStats @controllers.NearlineDataController.archivedStatsData
 GET     /api/nearline/byCloggingStatus @controllers.NearlineDataController.byCloggingStatus(status:Option[String])
 
+GET     /api/unclog/mediaStatus     @controllers.UnclogNearlineDataController.mediaStatusStats
+
 GET     /api/jobs/:jobType/forTimespan  @controllers.JobsController.jobsForTimespan(jobType, startAt:Option[String]?=None,endAt:Option[String]?=None,showRunning:Boolean?=false)
 GET     /api/jobs/running               @controllers.JobsController.runningJobs(limit:Option[Int])
 GET     /api/jobs/:jobType/lastSuccess  @controllers.JobsController.lastSuccessfulJob(jobType, includeRunning:Boolean?=false)

--- a/conf/routes
+++ b/conf/routes
@@ -17,6 +17,8 @@ GET     /api/nearline/archivedStats @controllers.NearlineDataController.archived
 GET     /api/nearline/byCloggingStatus @controllers.NearlineDataController.byCloggingStatus(status:Option[String])
 
 GET     /api/unclog/mediaStatus     @controllers.UnclogNearlineDataController.mediaStatusStats
+GET     /api/unclog/mediaStatus/:status/records @controllers.UnclogNearlineDataController.recordsForMediaStatus(status, startAt:Option[Int], limit:Option[Int])
+GET     /api/unclog/mediaStatus/:status/projects @controllers.UnclogNearlineDataController.projectsForMediaStatus(status)
 
 GET     /api/jobs/:jobType/forTimespan  @controllers.JobsController.jobsForTimespan(jobType, startAt:Option[String]?=None,endAt:Option[String]?=None,showRunning:Boolean?=false)
 GET     /api/jobs/running               @controllers.JobsController.runningJobs(limit:Option[Int])

--- a/frontend/app/NearlineUnclog.jsx
+++ b/frontend/app/NearlineUnclog.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import axios from 'axios';
+import {Pie,Bar,HorizontalBar} from "react-chartjs-2";
+import NearlineControlsBanner from "./common/NearlineControlsBanner.jsx";
+
+class NearlineUnclog extends React.Component {
+    constructor(props){
+        super(props);
+
+        this.state = {
+            loading: false,
+            lastError:null,
+            chartMode: NearlineControlsBanner.CHART_MODE_COUNT,
+            allData: null
+        };
+
+        this.refresh = this.refresh.bind(this);
+    }
+
+    static makeColourValues(count, offset){
+        let values = [];
+        for(let n=0;n<count;++n){
+            let hue = (n/count)*360.0 + offset;
+            values[n] = 'hsla(' + hue + ',75%,50%,0.6)'
+        }
+        return values;
+    }
+
+    static colourValues = NearlineUnclog.makeColourValues(17, 10);
+
+    refresh(){
+        this.setState({loading: true}, ()=>axios.get("/api/unclog/mediaStatus").then(response=>{
+            this.setState({loading: false, allData: response.data});
+        }).catch(err=>{
+            this.setState({loading: false, lastError: err})
+        }));
+    }
+
+    componentWillMount() {
+        this.refresh();
+    }
+
+    refreshChartData(){
+        this.refresh();
+    }
+
+    render(){
+        return <div>
+            <NearlineControlsBanner dataMode={this.state.chartMode}
+                                    dataModeChanged={evt=>this.setState({chartMode: parseInt(evt.target.value)},()=>this.refreshChartData())}
+                                    isRunning={this.state.loading}
+                                    refreshClicked={this.refresh}
+                                    />
+
+            <div style={{width: "100vw",  overflow:"hidden"}}>
+
+            </div>
+            <HorizontalBar data={{
+
+                datasets: this.state.allData ? this.state.allData.map((datapoint,idx)=>{
+                    let data;
+                    if(this.state.chartMode===NearlineControlsBanner.CHART_MODE_COUNT){
+                        data = [datapoint.count];
+                    } else if(this.state.chartMode===NearlineControlsBanner.CHART_MODE_SIZE){
+                        data = [datapoint.size];
+                    } else {
+                        throw "Invalid mode for component, should be count or size."
+                    }
+                    return {data: data,label:datapoint.label, backgroundColor: NearlineUnclog.colourValues[idx*2]}
+                }) : [],
+                labels: ["Files"]
+            }}
+           height={50}
+           options={{scales: {
+                   yAxes: [{stacked: true}],
+                   xAxes: [{
+                       stacked: true,
+                       labelString: this.state.chartMode===NearlineControlsBanner.CHART_MODE_SIZE ? "Total size" : "File count",
+                       ticks: {
+                           callback: (value,index,series)=>
+                               this.state.chartMode===NearlineControlsBanner.CHART_MODE_SIZE ? Math.floor(value/1099511627776) + "Tib" : value
+                       }
+                   }]
+
+               }
+           }}
+
+            />
+        </div>
+
+    }
+}
+
+export default NearlineUnclog;

--- a/frontend/app/NearlineUnclog.jsx
+++ b/frontend/app/NearlineUnclog.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import {Pie,Bar,HorizontalBar} from "react-chartjs-2";
 import NearlineControlsBanner from "./common/NearlineControlsBanner.jsx";
 import ProjectSearchView from "./ProjectSearchView.jsx";
+import BytesFormatterImplementation from "./common/BytesFormatterImplementation.jsx";
 
 class NearlineUnclog extends React.Component {
     constructor(props){
@@ -31,6 +32,17 @@ class NearlineUnclog extends React.Component {
 
     static colourValues = NearlineUnclog.makeColourValues(19, 10);
 
+    static makeHoverColourValues(count, offset){
+        let values = [];
+        for(let n=0;n<count;++n){
+            let hue = (n/count)*360.0 + offset;
+            values[n] = 'hsla(' + hue + ',75%,50%,0.8)'
+        }
+        return values;
+    }
+
+    static hoverColourValues = NearlineUnclog.makeHoverColourValues(19, 10);
+
     refresh(){
         this.setState({loading: true}, ()=>axios.get("/api/unclog/mediaStatus").then(response=>{
             this.setState({loading: false, allData: response.data});
@@ -54,10 +66,6 @@ class NearlineUnclog extends React.Component {
                                     isRunning={this.state.loading}
                                     refreshClicked={this.refresh}
                                     />
-
-            <div style={{width: "100vw",  overflow:"hidden"}}>
-
-            </div>
             <HorizontalBar data={{
 
                 datasets: this.state.allData ? this.state.allData.map((datapoint,idx)=>{
@@ -69,7 +77,7 @@ class NearlineUnclog extends React.Component {
                     } else {
                         throw "Invalid mode for component, should be count or size."
                     }
-                    return {data: data,label:datapoint.label, backgroundColor: NearlineUnclog.colourValues[idx*2]}
+                    return {data: data,label:datapoint.label, backgroundColor: NearlineUnclog.colourValues[idx*2], hoverBackgroundColor: NearlineUnclog.hoverColourValues[idx*2] }
                 }) : [],
                 labels: ["Files"]
             }}
@@ -85,6 +93,31 @@ class NearlineUnclog extends React.Component {
                        }
                    }]
 
+               },
+               tooltips: {
+                   callbacks: {
+                       label: (tooltipItem,data)=>{
+                           let xLabel=data.datasets[tooltipItem.datasetIndex].label;
+                           let yLabel=data.datasets[tooltipItem.datasetIndex].data;
+
+                           console.log(tooltipItem);
+                           console.log(data);
+                           console.log(xLabel, yLabel);
+
+                           if(this.state.chartMode===NearlineControlsBanner.CHART_MODE_SIZE) {
+                               try {
+                                   const result = BytesFormatterImplementation.getValueAndSuffix(yLabel);
+                                   yLabel = result[0] + result[1];
+                                   return xLabel + ": " + yLabel;
+                               } catch (err) {
+                                   console.error(err);
+                                   return xLabel + ": " + yLabel;
+                               }
+                           } else {
+                               return xLabel + ": " + yLabel;
+                           }
+                       }
+                   }
                }
            }}
            getElementAtEvent = {elems=>{

--- a/frontend/app/NearlineUnclog.jsx
+++ b/frontend/app/NearlineUnclog.jsx
@@ -26,7 +26,7 @@ class NearlineUnclog extends React.Component {
         return values;
     }
 
-    static colourValues = NearlineUnclog.makeColourValues(17, 10);
+    static colourValues = NearlineUnclog.makeColourValues(19, 10);
 
     refresh(){
         this.setState({loading: true}, ()=>axios.get("/api/unclog/mediaStatus").then(response=>{
@@ -83,6 +83,10 @@ class NearlineUnclog extends React.Component {
                    }]
 
                }
+           }}
+           getElementAtEvent = {elems=>{
+               const bar = elems[0];
+               console.log("You clicked on bar number ", bar._datasetIndex, bar._model.datasetLabel);
            }}
 
             />

--- a/frontend/app/NearlineUnclog.jsx
+++ b/frontend/app/NearlineUnclog.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import {Pie,Bar,HorizontalBar} from "react-chartjs-2";
 import NearlineControlsBanner from "./common/NearlineControlsBanner.jsx";
+import ProjectSearchView from "./ProjectSearchView.jsx";
 
 class NearlineUnclog extends React.Component {
     constructor(props){
@@ -11,7 +12,9 @@ class NearlineUnclog extends React.Component {
             loading: false,
             lastError:null,
             chartMode: NearlineControlsBanner.CHART_MODE_COUNT,
-            allData: null
+            allData: null,
+            showProjectsList: false,
+            selectedProjectStatus: null
         };
 
         this.refresh = this.refresh.bind(this);
@@ -87,9 +90,14 @@ class NearlineUnclog extends React.Component {
            getElementAtEvent = {elems=>{
                const bar = elems[0];
                console.log("You clicked on bar number ", bar._datasetIndex, bar._model.datasetLabel);
+               this.setState({selectedProjectStatus: bar._model.datasetLabel, showProjectsList: true});
            }}
 
             />
+            <div>
+                <br />
+            <ProjectSearchView projectStatus={this.state.selectedProjectStatus} visible={this.state.showProjectsList}/>
+        </div>
         </div>
 
     }

--- a/frontend/app/ProjectSearchView.jsx
+++ b/frontend/app/ProjectSearchView.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+import PropTypes from "prop-types";
+import axios from "axios";
+import ErrorViewComponent from "./common/ErrorViewComponent.jsx";
+import BytesFormatter from "./common/BytesFormatter.jsx";
+
+class ProjectSearchView extends React.Component {
+    static propTypes = {
+        visible: PropTypes.bool.isRequired,
+        projectStatus: PropTypes.string
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            loading: false,
+            projectsList: [],
+            totalCount: 0,
+            lastError: null
+        }
+    }
+
+    componentWillMount() {
+        this.reloadData();
+    }
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        console.log("ProjectSearch update: ", prevProps, this.props);
+
+        if ((prevProps.projectStatus !== this.props.projectStatus) && this.props.visible) {
+            console.log("Reloading data");
+            this.reloadData();
+        }
+    }
+
+    reloadData() {
+        let uriParams = {};
+        if (this.props.projectStatus) {
+            uriParams["status"] = this.props.projectStatus;
+        }
+        console.log(uriParams);
+        if (Object.keys(uriParams).length > 0) {
+            const uri = "/api/unclog/mediaStatus/" + this.props.projectStatus +"/projects";
+
+            this.setState({loading: true}, () => axios.get(uri).then(result => {
+                this.setState({
+                    loading: false,
+                    lastError: null,
+                    totalCount: result.data.entry.length,
+                    projectsList: result.data.entry
+                })
+            }).catch(err => {
+                this.setState({
+                    loading: false,
+                    lastError: err
+                })
+            }))
+        }
+    }
+
+    render() {
+        if (this.state.lastError) return <ErrorViewComponent error={this.state.lastError}/>;
+
+        return <table className="dashboardpanel"
+                      style={{width: "100%", display: this.props.visible ? "block" : "none"}}>
+            <thead>
+            <tr className="dashboardheader">
+                <td style={{width:"50px"}}>Project</td>
+                <td style={{width:"120px"}}>File Count</td>
+                <td style={{width:"200px"}}>File Size</td>
+            </tr>
+            </thead>
+            <tbody>
+            {this.state.projectsList.map(entry => {
+                return <tr>
+                    <td><a href={"https://pluto.gnm.int/project/"+entry.label} target="_blank">{entry.label}</a></td>
+                    <td>{entry.count}</td>
+                    <td>{entry.size}</td>
+
+                </tr>
+            })}
+            {
+                this.state.projectsList.length < this.state.totalCount ?
+                    <tr><td colSpan={7} style={{textAlign:"center"}}><i>Results limited to {this.state.projectsList.length}</i></td></tr> :
+                    <tr><td colSpan={7} style={{textAlign:"center"}}><i>All results shown</i></td></tr>
+            }
+            </tbody>
+        </table>
+    }
+}
+
+export default ProjectSearchView;

--- a/frontend/app/ProjectSearchView.jsx
+++ b/frontend/app/ProjectSearchView.jsx
@@ -85,7 +85,7 @@ class ProjectSearchView extends React.Component {
             </tbody>
         </table>
         </div>
-            <div className="projectdata">Projects with this status: {this.props.projectNumber}</div>
+            <div className="projectdata">Projects containing files with this status: {this.props.projectNumber}</div>
         </div>
     }
 }

--- a/frontend/app/ProjectSearchView.jsx
+++ b/frontend/app/ProjectSearchView.jsx
@@ -81,8 +81,8 @@ class ProjectSearchView extends React.Component {
                 </tr>
             })}
             {
-                this.state.projectsList.length < this.state.totalCount ?
-                    <tr><td colSpan={7} style={{textAlign:"center"}}><i>Results limited to {this.state.projectsList.length}</i></td></tr> :
+                this.state.projectsList.length > 128 ?
+                    <tr><td colSpan={7} style={{textAlign:"center"}}><i>More than 128 projects found</i></td></tr> :
                     <tr><td colSpan={7} style={{textAlign:"center"}}><i>All results shown</i></td></tr>
             }
             </tbody>

--- a/frontend/app/ProjectSearchView.jsx
+++ b/frontend/app/ProjectSearchView.jsx
@@ -7,7 +7,8 @@ import BytesFormatter from "./common/BytesFormatter.jsx";
 class ProjectSearchView extends React.Component {
     static propTypes = {
         visible: PropTypes.bool.isRequired,
-        projectStatus: PropTypes.string
+        projectStatus: PropTypes.string,
+        projectNumber: PropTypes.string
     };
 
     constructor(props) {
@@ -26,8 +27,6 @@ class ProjectSearchView extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
-        console.log("ProjectSearch update: ", prevProps, this.props);
-
         if ((prevProps.projectStatus !== this.props.projectStatus) && this.props.visible) {
             console.log("Reloading data");
             this.reloadData();
@@ -39,7 +38,7 @@ class ProjectSearchView extends React.Component {
         if (this.props.projectStatus) {
             uriParams["status"] = this.props.projectStatus;
         }
-        console.log(uriParams);
+
         if (Object.keys(uriParams).length > 0) {
             const uri = "/api/unclog/mediaStatus/" + this.props.projectStatus +"/projects";
 
@@ -62,13 +61,12 @@ class ProjectSearchView extends React.Component {
     render() {
         if (this.state.lastError) return <ErrorViewComponent error={this.state.lastError}/>;
 
-        return <table className="dashboardpanel"
-                      style={{width: "100%", display: this.props.visible ? "block" : "none"}}>
+        return <div style={{display: this.props.visible ? "block" : "none"}}><div className="projectdata">{this.props.projectStatus}<br /><br /><table className="dashboardpanel">
             <thead>
             <tr className="dashboardheader">
                 <td style={{width:"50px"}}>Project</td>
                 <td style={{width:"120px"}}>File Count</td>
-                <td style={{width:"200px"}}>File Size</td>
+                <td style={{width:"200px"}}>Data Size</td>
             </tr>
             </thead>
             <tbody>
@@ -76,8 +74,7 @@ class ProjectSearchView extends React.Component {
                 return <tr>
                     <td><a href={"https://pluto.gnm.int/project/"+entry.label} target="_blank">{entry.label}</a></td>
                     <td>{entry.count}</td>
-                    <td>{entry.size}</td>
-
+                    <td><BytesFormatter value={entry.size}/></td>
                 </tr>
             })}
             {
@@ -87,6 +84,9 @@ class ProjectSearchView extends React.Component {
             }
             </tbody>
         </table>
+        </div>
+            <div className="projectdata">Projects with this status: {this.props.projectNumber}</div>
+        </div>
     }
 }
 

--- a/frontend/app/common/NearlineControlsBanner.jsx
+++ b/frontend/app/common/NearlineControlsBanner.jsx
@@ -21,6 +21,7 @@ class NearlineControlsBanner extends React.Component {
                 <Link className="controls-banner-spacing" to="/nearlines">Nearline Stats</Link> |
                 <Link className="controls-banner-spacing" to="/nearlines/membership">Nearline files without item membership</Link> |
                 <Link className="controls-banner-spacing" to="/nearlines/archived">Nearline-Archive Crossover</Link> |
+                <Link className="controls-banner-spacing" to="/nearlines/unclog">Unclog</Link> |
                 <select className="controls-banner-spacing" value={this.props.dataMode} onChange={this.props.dataModeChanged}>
                     <option key={NearlineControlsBanner.CHART_MODE_COUNT} value={NearlineControlsBanner.CHART_MODE_COUNT}>View by file count</option>
                     <option key={NearlineControlsBanner.CHART_MODE_SIZE} value={NearlineControlsBanner.CHART_MODE_SIZE}>View by file size</option>

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -15,6 +15,7 @@ import RunsAdmin from "./RunsAdmin.jsx";
 import NearlineStorages from "./NearlineStorages.jsx";
 import NearlineStorageMembership from "./NearlineStorageMembership.jsx";
 import NearlineStorageArchived from "./NearlineStorageArchived.jsx";
+import NearlineUnclog from "./NearlineUnclog.jsx";
 
 library.add(faStroopwafel, faCheckCircle, faCheck, faTimes, faTimesCircle, faRoad,faSearch,faThList,faWrench, faLightbulb, faChevronCircleDown, faChevronCircleRight, faTrashAlt, faFolderPlus, faFolderMinus, faFolder);
 library.add(faFilm, faVolumeUp, faImage, faFile, faClock, faRunning, faExclamationTriangle, faHdd, faBalanceScale, faSyncAlt, faBookReader, faBug, faCompressArrowsAlt, faIndustry, faRedoAlt, faHome, faListOl,);
@@ -31,6 +32,7 @@ class App extends React.Component {
                 <Route path="/runs" component={RunsAdmin}/>
                 <Route path="/nearlines/archived" component={NearlineStorageArchived}/>
                 <Route path="/nearlines/membership" component={NearlineStorageMembership}/>
+                <Route path="/nearlines/unclog" component={NearlineUnclog}/>
                 <Route path="/nearlines" component={NearlineStorages}/>
                 <Route path="/" component={IndexRedirect}/>
             </Switch>

--- a/public/stylesheets/mediacensus.css
+++ b/public/stylesheets/mediacensus.css
@@ -229,3 +229,7 @@ ul.no-bullets {
     overflow: hidden;
     align-content: center;
 }
+
+div.projectdata {
+    float: left;
+}

--- a/unclognearline/src/main/resources/logback.xml
+++ b/unclognearline/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+
+
+    <root level="DEBUG">
+        <appender-ref ref="ASYNCSTDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
Adds a new page with a graph showing files by status. Clicking on the bars brings up a list of projects with that status.

![image](https://user-images.githubusercontent.com/10620802/76870337-7ad33580-6861-11ea-8119-4156e89a637d.png)

Tested on a machine running macOS 10.12.6 and a Kubernetes cluster.

@fredex42 